### PR TITLE
Update to allow add extra services

### DIFF
--- a/nanoFramework.Device.Bluetooth.nuspec
+++ b/nanoFramework.Device.Bluetooth.nuspec
@@ -19,7 +19,8 @@
     <tags>nanoFramework C# csharp netmf netnf nanoFramework.Device.Bluetooth</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.12.0-preview.9" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.10.0-preview.8" />
+		<dependency id="nanoFramework.Runtime.Native" version="1.5.4-preview.5" />
+		<dependency id="nanoFramework.Runtime.Events" version="1.10.0-preview.8" />
       <dependency id="nanoFramework.System.Text" version="1.1.3-preview.15" />
     </dependencies>
   </metadata>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristicUuids.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristicUuids.cs
@@ -15,12 +15,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
     public static class GattCharacteristicUuids
     {
         /// <summary>
-        /// Gets the Bluetooth SIG-defined Heart Rate Measurement Characteristic UUID (0x2A37)
-        /// </summary>
-        public static Guid HeartRateMeasurement { get => Utilities.CreateUuidFromShortCode(0x2A37); }
-
-        /// <summary>
         /// Gets the Bluetooth SIG-defined Battery Level Characteristic UUID (0x2A19).
+        /// Percentage 0% to 100%, byte
         /// </summary>
         public static Guid BatteryLevel { get => Utilities.CreateUuidFromShortCode(0x2A19); }
 
@@ -70,6 +66,17 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public static Guid HeartRateControlPoint { get => Utilities.CreateUuidFromShortCode(0x2A39); }
 
         /// <summary>
+        /// Gets the Bluetooth SIG-defined Heart Rate Measurement Characteristic UUID (0x2A37)
+        /// </summary>
+        public static Guid HeartRateMeasurement { get => Utilities.CreateUuidFromShortCode(0x2A37); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Humidity Characteristic UUID (0x2A6F)
+        /// Uint16, Percentage 0-100 expressed in 0.01 units, 50%=5000
+        /// </summary>
+        public static Guid Humidity { get => Utilities.CreateUuidFromShortCode(0x2A6F); }
+
+        /// <summary>
         /// Gets the Bluetooth SIG-defined Intermediate Cuff Pressure Characteristic UUID (0x2A36).
         /// </summary>
         public static Guid IntermediateCuffPressure { get => Utilities.CreateUuidFromShortCode(0x2A36); }
@@ -83,6 +90,18 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// Gets the Bluetooth SIG-defined Measurement Interval Characteristic UUID (0x2A21).
         /// </summary>
         public static Guid MeasurementInterval { get => Utilities.CreateUuidFromShortCode(0x2A21); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Pressure Characteristic UUID (0x2A6D).
+        /// Uint32, Unit is Pascal with resolution of 0.1 Pa
+        /// </summary>
+        public static Guid Pressure { get => Utilities.CreateUuidFromShortCode(0x2A6D); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Rainfall Characteristic UUID (0x2A78).
+        /// Uint16, Unit is Meters with resolution of 1mm
+        /// </summary>
+        public static Guid Rainfall { get => Utilities.CreateUuidFromShortCode(0x2A78); }
 
         /// <summary>
         /// Gets the Bluetooth SIG-defined Record Access Control Point Characteristic UUID (0x2A52).
@@ -108,6 +127,12 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// Gets the Bluetooth SIG-defined Sensor Location Characteristic UUID (0x2A5D).
         /// </summary>
         public static Guid SensorLocation { get => Utilities.CreateUuidFromShortCode(0x2A5D); }
+
+        /// <summary>
+        ///  Gets the Bluetooth SIG-defined Temperature Characteristic UUID (0x2A6E).
+        ///  Int16, -273.15 to 327.67 Celsius. Resolution 0.01,  89.5c = 8950
+        /// </summary>
+        public static Guid Temperature { get => Utilities.CreateUuidFromShortCode(0x2a6e); }
 
         /// <summary>
         ///  Gets the Bluetooth SIG-defined Temperature Measurement Characteristic UUID (0x2a1c).

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattDescriptorUuid.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattDescriptorUuid.cs
@@ -43,5 +43,30 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// Gets the Bluetooth SIG-defined Server Characteristic Configuration Descriptor UUID.
         /// </summary>
         public static Guid ServerCharacteristicConfiguration { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.ServerCharacteristicConfiguration); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Value trigger settings Descriptor UUID.
+        /// </summary>
+        public static Guid ValueTriggerSetting { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.ValueTriggerSetting); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Environmental Sensing Configuration Descriptor UUID.
+        /// </summary>
+        public static Guid EssConfiguration { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.EssConfiguration); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Environmental Sensing Measurement Descriptor UUID.
+        /// </summary>
+        public static Guid EssMeasurement { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.EssMeasurement); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Environmental Sensing Trigger Setting Descriptor UUID.
+        /// </summary>
+        public static Guid EssTriggerSetting { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.EssTriggerSetting); }
+
+        /// <summary>
+        /// Gets the Bluetooth SIG-defined Time Trigger Setting  Descriptor UUID.
+        /// </summary>
+        public static Guid TimeTriggerSetting { get => Utilities.CreateUuidFromShortCode((ushort)Utilities.GattNativeDescriptorUuid.TimeTriggerSetting); }
     }
 }

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
@@ -205,7 +205,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// <summary>
         ///  Gets a vector list of all the descriptors for this local characteristic.
         /// </summary>
-        public GattLocalDescriptor[] Descriptors { get => (GattLocalDescriptor[])_descriptors.ToArray(); }
+        public GattLocalDescriptor[] Descriptors { get => (GattLocalDescriptor[])_descriptors.ToArray(typeof(GattLocalDescriptor)); }
 
         /// <summary>
         /// Gets the presentation formats for this local characteristic.

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalService.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalService.cs
@@ -20,7 +20,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         {
             _serviceUuid = serviceUuid.ToByteArray();
             _characteristics = new ArrayList();
-            _characteristics.Add(new GattLocalCharacteristic(serviceUuid, new GattLocalCharacteristicParameters()));
         }
 
         /// <summary>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -5,16 +5,18 @@
 
 using System;
 using System.Text;
+using System.Collections;
 using System.Runtime.CompilerServices;
+using nanoFramework.Runtime.Native;
 
 namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 {
     /// <summary>
-    /// This class is used to advertise a GATT service.
+    /// This class is used to advertise a GATT services.
     /// </summary>
     public sealed class GattServiceProvider
     {
-        private readonly GattLocalService _service;
+        private readonly ArrayList _services;
 
         GattServiceProviderAdvertisementStatus _status = GattServiceProviderAdvertisementStatus.Created;
 
@@ -35,9 +37,46 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 
         internal GattServiceProvider(Guid serviceUuid)
         {
-            _service = new GattLocalService(serviceUuid);
+            _services = new ArrayList();
+
+            // Add primary
+            AddService(serviceUuid);
+
+            // Add default Device Information service 
+            AddDeviceInformationService();
 
             NativeInitService();
+        }
+
+        /// <summary>
+        /// Add default Device Information Service
+        /// </summary>
+        private void AddDeviceInformationService()
+        {
+            // Add and initialised Device Information defaults
+            GattLocalService dinfService = AddService(GattServiceUuids.DeviceInformation);
+
+            // ManufacturerNameString Characteristic (0x2A29)
+            DataWriter manufacturerName = new DataWriter();
+            manufacturerName.WriteString("Nanoframework");
+
+            dinfService.CreateCharacteristic(GattCharacteristicUuids.ManufacturerNameString,
+                new GattLocalCharacteristicParameters()
+                {
+                    StaticValue = manufacturerName.DetachBuffer(),
+                    CharacteristicProperties = GattCharacteristicProperties.Read
+                });
+
+            // ModelNumberString Characteristic (0x2A24)
+            DataWriter modelNumber = new DataWriter();
+            modelNumber.WriteString(SystemInfo.Platform);
+
+            dinfService.CreateCharacteristic(GattCharacteristicUuids.ModelNumberString,
+                new GattLocalCharacteristicParameters()
+                {
+                    StaticValue = modelNumber.DetachBuffer(),
+                    CharacteristicProperties = GattCharacteristicProperties.Read
+                });
         }
 
         /// <summary>
@@ -96,10 +135,46 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public GattServiceProviderAdvertisementStatus AdvertisementStatus { get => _status; }
 
         /// <summary>
-        /// Gets the GATT service.
+        /// Gets the GATT primary service.
         /// </summary>
-        /// <returns>The GATT service.</returns>
-        public GattLocalService Service { get => _service; }
+        /// <returns>The primary service.</returns>
+        public GattLocalService Service { get => Services[0]; }
+
+        /// <summary>
+        /// Get an array of all associated services for this service provider.
+        /// </summary>
+        /// <remarks>
+        /// The primary service will be index 0 followed by the Device Information at index 1.
+        /// Any other Services added to provider will follow these in the order they were created.
+        /// </remarks>
+        public GattLocalService[] Services { get { return (GattLocalService[])_services.ToArray(typeof(GattLocalService)); } }
+
+        /// <summary>
+        /// Creates a new service or replaces an existing service.
+        /// Created service is added to this service provider.
+        /// </summary>
+        /// <param name="serviceUuid">Uuid for the service to be created/replaced.</param>
+        /// <returns>
+        /// Returns the created service.
+        /// </returns>
+        public GattLocalService AddService(Guid serviceUuid)
+        {
+            for (int index = 0; index < _services.Count; index++)
+            {
+                if (((GattLocalService)_services[index]).Uuid.Equals(serviceUuid))
+                {
+                    // Replace existing service on index
+                    GattLocalService replacementService = new GattLocalService(serviceUuid);
+                    _services[index] = replacementService;
+                    return replacementService;
+                }
+            }
+
+            // Add new service
+            GattLocalService newService = new GattLocalService(serviceUuid);
+            _services.Add(newService);
+            return newService;
+        }
 
         #region external calls to native implementations
 

--- a/nanoFramework.Device.Bluetooth/Utilities.cs
+++ b/nanoFramework.Device.Bluetooth/Utilities.cs
@@ -60,7 +60,37 @@ namespace nanoFramework.Device.Bluetooth
             /// <summary>
             /// ReportReference
             /// </summary>
-            ReportReference = 0x2908
+            ReportReference = 0x2908,
+
+            /// <summary>
+            /// Number of Digitals 
+            /// </summary>
+            NumberDigitals = 0x2909,
+
+            /// <summary>
+            /// Value trigger settings
+            /// </summary>
+            ValueTriggerSetting = 0x290A,
+
+            /// <summary>
+            /// Environmental Sensing Configuration
+            /// </summary>
+            EssConfiguration = 0x290B,
+
+            /// <summary>
+            /// Environmental Sensing Measurement
+            /// </summary>
+            EssMeasurement = 0x290C,
+
+            /// <summary>
+            /// Environmental Sensing Trigger Setting
+            /// </summary>
+            EssTriggerSetting = 0x290D,
+
+            /// <summary>
+            /// Time Trigger Setting 
+            /// </summary>
+            TimeTriggerSetting = 0x290E
         }
 
         /// <summary>

--- a/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
+++ b/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
@@ -91,6 +91,11 @@
       <HintPath>..\packages\nanoFramework.Runtime.Events.1.10.0-preview.8\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.5.4-preview.5\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Text.1.1.3-preview.15\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>

--- a/nanoFramework.Device.Bluetooth/packages.config
+++ b/nanoFramework.Device.Bluetooth/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.12.0-preview.9" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.10.0-preview.8" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.5.4-preview.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.1.3-preview.15" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.231" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
## Description

Allows extra services to be added to the primary service which extends functionality over the windows UWP version.
This allows extra services to be added to the provider with no restrictions.

If a service is the same UUID as existing service then it replaces that service.

For issue 942 this allows default Device information service to be replaced.

The added bonus is you can now easily add standard services to your application.
Bluetooth Sample 3 is includes 4 standard services that can be reused.


## Motivation and Context
- Resolves nanoFramework/Home#942
- 
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Using 3 new Bluetooth samples. To be added when this nuget is available

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
