### PR TITLE
Changes to allow scanning and connections to work together

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is based on the Windows.Devices.Bluetooth UWP class library but sim
 The original .Net assembly depended on Windows.Storage.Streams for DataReader & DataWriter; this library has simplified inbuilt versions. 
 So references to IBuffer in .Net UWP examples should now use Buffer instead. 
 
-We have also added an extension to this assembly allowing extra services to be added with no restriction on type.
+We have also added an extension to this assembly allowing extra services to be added to ServiceProvider with no restriction on type.
 
 ## Firmware versions
 
@@ -28,6 +28,7 @@ Bluetooth is currently only supported on ESP32 devices with following firmware.
 
 - ESP32_BLE_REV0
 - ESP32_BLE_REV3
+- M5Core2
 
 This restriction is due to IRAM memory space in the firmware image. 
 With revision 1 of ESP32 devices, the PSRAM implementation requires a large number of PSRAM fixes which greatly reduces the 
@@ -51,9 +52,10 @@ A number of Bluetooth LE samples are available in the [nanoFramework samples rep
 
 This implementation supports a cut down version of the Gatt Server and Gatt Client implementation.
 
-The device can either run as a Server, Client or Watcher, but not at the same time.  
+The device can either run as a Server or Client, but not at the same time.  
 For example if you start a Watcher to look for advertisements from Server devices you will not 
-be able to connect to those devices until the Watcher has been stopped.
+be able to connect to those devices until the Watcher has been stopped. But you can recieve data from connected 
+devices while Watcher is scanning.
 
 For more information see relevant sections: -
 
@@ -343,7 +345,7 @@ RSSI filter
 
 ## Creating a device and connecting to device.
 
-To communicate with a device a BluetoothLEDevice class needs to be created using the devices bluetooth address.
+To communicate with a device a BluetoothLEDevice class needs to be created using the devices bluetooth address and type.
 This can be the bluetooth address from the BluetoothLEAdvertisementWatcher event or using a hard coded address.
 
 In this case from the Watcher advertisement received event.
@@ -352,11 +354,12 @@ BluetoothLEDevice device = BluetoothLEDevice.FromBluetoothAddress(args.Bluetooth
 ```
 There are no specific connection methods but a connection will be made automatically when you query the device 
 for its services. The ConnectionStatusChanged event can used to detect a change in connection status and an attempt to 
-reconnect can be done by query the devices services again. Avoid doing this in the event it self as it can block other 
+reconnect can be done by a query to the devices services again. Avoid doing this in the event, as it can block other 
 events being fired during the connection.
 
-To go back to Watching for advertisements all connected devices need to be closed or disposed. This
-will put the stack in to an idle state so the Watching can be started.
+You can go back to Watching for advertisements with the restriction that you can't connect to newly found devcies until the Watching is stopped.
+You can still communication with connected devices while the Watcher is running. Best way is to collect all found devices in a table until Watcher is
+stopped then connect to all found devices. See [Central 2 sample](https://github.com/nanoframework/Samples/tree/main/samples/Bluetooth/Central2)
 
 The Close() method is not exposed in the desktop version but it has been implemented in this version 
 to give better control over the connection.

--- a/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
@@ -68,13 +68,8 @@ namespace nanoFramework.Device.Bluetooth
         /// </summary>
         public void Start()
         {
-            if (BluetoothNanoDevice.RunMode != BluetoothNanoDevice.Mode.NotRunning)
-            {
-                throw new InvalidOperationException("Wrong state");
-            }
-
-            // Set new run mode. 
-            BluetoothNanoDevice.RunMode = BluetoothNanoDevice.Mode.Scanning;
+            // Check and set mode
+            BluetoothNanoDevice.CheckMode(BluetoothNanoDevice.Mode.Client);
 
             _status = BluetoothLEAdvertisementWatcherStatus.Started;
             _scanResults = new Hashtable();
@@ -97,7 +92,7 @@ namespace nanoFramework.Device.Bluetooth
 
             _status = BluetoothLEAdvertisementWatcherStatus.Stopped;
 
-            BluetoothNanoDevice.RunMode = BluetoothNanoDevice.Mode.NotRunning;
+            BluetoothLEDevice.IdleOnLastConnection();
         }
 
         /// <summary>

--- a/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
@@ -9,13 +9,14 @@
 //  As we can't run both Server or Central/Client at same time
 //
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace nanoFramework.Device.Bluetooth
 {
     internal static class BluetoothNanoDevice
     {
-        internal enum Mode { NotRunning, Server, Scanning, Central };
+        internal enum Mode { NotRunning, Server, Client };
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private static string _deviceName = "";
@@ -29,6 +30,18 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         internal static string DeviceName { get => _deviceName; set => _deviceName = value; }
+
+        internal static void CheckMode(Mode expectedMode)
+        {
+            if (BluetoothNanoDevice.RunMode != expectedMode &&
+                BluetoothNanoDevice.RunMode != Mode.NotRunning)
+            {
+                throw new InvalidOperationException("Wrong state");
+            }
+
+            // Set new run mode. 
+            BluetoothNanoDevice.RunMode = expectedMode;
+        }
 
         /// <summary>
         /// Get/Set the current mode of the device.

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -95,15 +95,10 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// <param name="parameters">The advertising parameters.</param>
         public void StartAdvertising(GattServiceProviderAdvertisingParameters parameters)
         {
-            if (BluetoothNanoDevice.RunMode != BluetoothNanoDevice.Mode.NotRunning)
-            {
-                throw new InvalidOperationException("Wrong state");
-            }
+            // Check and switch to server mode
+            BluetoothNanoDevice.CheckMode(BluetoothNanoDevice.Mode.Server);
 
             BluetoothNanoDevice.DeviceName = parameters.DeviceName;
-
-            // Switch to client/server mode
-            BluetoothNanoDevice.RunMode = BluetoothNanoDevice.Mode.Server;
 
             // Save parameters
             _isConnectable = parameters.IsConnectable;

--- a/nanoFramework.Device.Bluetooth/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Device.Bluetooth/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.1.0")]
+[assembly: AssemblyNativeVersion("100.0.2.0")]
 ////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
## Description

Changes to stop stack being closed down between scanning using Watcher and Connections to devices. 

Central 2 sample & Documentation updated to reflect change

## Motivation and Context
Reported in Discord

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

See nanoframework PR for details
https://github.com/nanoframework/nf-interpreter/pull/2428

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
