### PR TITLE
Updates for Pairing (Security and Authentication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,14 +590,12 @@ Where:-
 * *Passkey R&I*  : PassKey is inputted on initiator and responder.
 * *Compare(sec)* : Numeric comparison when using secure connection. Both ends input and display passkey.
 
-
 ### Common use cases for IOCapabilities.
 
 | Responder(Client) | Pairing | Initiator(Server) |
 | --------- | ----------- | ------------ |
 | *NoInputNoOutput* | Just Works | *NoInputNoOutput* |
 | *KeyboardOnly* | PassKey input/sent from Client, Server checks | *DisplayOnly* |
-
 
 ### Code examples 
 
@@ -629,13 +627,12 @@ The client has to provide the correct passKey.
     // Add services and advertise
 
 ```
-
 ##### Event Handler for PairingRequested event. 
 
 The PairingKind indicates what the application needs to do.
 In this case its DevicePairingKinds.DisplayPin which just needs the passKey to compare with client.
 
-For a general use device with a display the passkey should be displayed so client knows what to input.
+For a general use device with a display the passkey should be displayd so client knows what to input.
 
 ```csharp
 private static void Pairing_PairingRequested(object sender, DevicePairingRequestedEventArgs args)
@@ -667,7 +664,6 @@ private static void Pairing_PairingComplete(object sender, DevicePairingEventArg
 
 
 #### Client
-
 
 ##### Setup of BluetoothLEDevice for pairing with Authenication.
 

--- a/Tests/Client/Program.cs
+++ b/Tests/Client/Program.cs
@@ -46,6 +46,8 @@ namespace TestClient
 
             Console.WriteLine("Create Primary service - UUID A7EEDF2C-DA87-4CB5-A9C5-5151C78B0066");
 
+            BluetoothLEServer.Instance.DeviceName = "Test2";
+
             //The GattServiceProvider is used to create and advertise the primary service definition.
             //An extra device information service will be automatically created.
             GattServiceProviderResult result = GattServiceProvider.Create(serviceUuid);
@@ -84,7 +86,6 @@ namespace TestClient
 
             // === Device Information Service ===
             DeviceInformationServiceService DifService = new(
-                    serviceProvider,
                     "nanoFramework",
                     "Test Client",
                     null, // no serial number
@@ -97,7 +98,7 @@ namespace TestClient
             // === Environmental Sensor Service ===
             // https://www.bluetooth.com/specifications/specs/environmental-sensing-service-1-0/
             // This service exposes measurement data from an environmental sensors.
-            EnvService = new EnvironmentalSensorService(serviceProvider);
+            EnvService = new EnvironmentalSensorService();
 
             // Add sensors to service, return index so sensor can be updated later.
             iTempOut = EnvService.AddSensor(EnvironmentalSensorService.SensorType.Temperature, "Outside Temp");
@@ -122,7 +123,6 @@ namespace TestClient
             // devices can see it with a specific device name.
             serviceProvider.StartAdvertising(new GattServiceProviderAdvertisingParameters()
             {
-                DeviceName = "Test2",
                 IsConnectable = true,
                 IsDiscoverable = true
             });

--- a/Tests/Client/Services/DeviceInformationService.cs
+++ b/Tests/Client/Services/DeviceInformationService.cs
@@ -38,7 +38,7 @@ namespace nanoFramework.Device.Bluetooth.Services
             GattServiceProviderResult pr = GattServiceProvider.Create(GattServiceUuids.DeviceInformation);
             if (pr.Error != BluetoothError.Success)
             {
-                throw new Exception("Unable to create service");
+                throw new ApplicationException("Unable to create service");
             }
 
             // Pick up service

--- a/Tests/Client/Services/DeviceInformationService.cs
+++ b/Tests/Client/Services/DeviceInformationService.cs
@@ -27,7 +27,6 @@ namespace nanoFramework.Device.Bluetooth.Services
         /// <param name="FirmwareRevision"></param>
         /// <param name="SoftwareRevision"></param>
         public DeviceInformationServiceService(
-            GattServiceProvider provider,
             string Manufacturer,
             string ModelNumber = null,
             string SerialNumber = null,
@@ -36,8 +35,14 @@ namespace nanoFramework.Device.Bluetooth.Services
             string SoftwareRevision = null
             )
         {
-            // Add new Device Information Service to provider
-            _deviceInformationService = provider.AddService(GattServiceUuids.DeviceInformation);
+            GattServiceProviderResult pr = GattServiceProvider.Create(GattServiceUuids.DeviceInformation);
+            if (pr.Error != BluetoothError.Success)
+            {
+                throw new Exception("Unable to create service");
+            }
+
+            // Pick up service
+            _deviceInformationService = pr.ServiceProvider.Service;
 
             CreateReadStaticCharacteristic(GattCharacteristicUuids.ManufacturerNameString, Manufacturer);
             CreateReadStaticCharacteristic(GattCharacteristicUuids.ModelNumberString, ModelNumber);

--- a/Tests/Client/Services/EnvironmentalSensorService.cs
+++ b/Tests/Client/Services/EnvironmentalSensorService.cs
@@ -40,9 +40,16 @@ namespace nanoFramework.Device.Bluetooth.Services
             public Buffer dataBuffer;
         };
 
-        public EnvironmentalSensorService(GattServiceProvider provider)
+        public EnvironmentalSensorService()
         {
-            _service = provider.AddService(GattServiceUuids.EnvironmentalSensing);
+            GattServiceProviderResult pr = GattServiceProvider.Create(GattServiceUuids.EnvironmentalSensing);
+            if (pr.Error != BluetoothError.Success)
+            {
+                throw new Exception("Unable to create service");
+            }
+
+            // Pick up service
+            _service = pr.ServiceProvider.Service;
             _sensors = new();
         }
 

--- a/Tests/Client/Services/EnvironmentalSensorService.cs
+++ b/Tests/Client/Services/EnvironmentalSensorService.cs
@@ -45,7 +45,7 @@ namespace nanoFramework.Device.Bluetooth.Services
             GattServiceProviderResult pr = GattServiceProvider.Create(GattServiceUuids.EnvironmentalSensing);
             if (pr.Error != BluetoothError.Success)
             {
-                throw new Exception("Unable to create service");
+                throw new ApplicationException("Unable to create service");
             }
 
             // Pick up service

--- a/Tests/Client/Services/TestService.cs
+++ b/Tests/Client/Services/TestService.cs
@@ -29,7 +29,7 @@ namespace nanoFramework.Device.Bluetooth.Services
             GattServiceProviderResult pr = GattServiceProvider.Create(serviceUUID);
             if (pr.Error != BluetoothError.Success)
             {
-                throw new Exception("Unable to create service");
+                throw new ApplicationException("Unable to create service");
             }
 
             _testService = pr.ServiceProvider.Service;

--- a/Tests/Client/Services/TestService.cs
+++ b/Tests/Client/Services/TestService.cs
@@ -24,11 +24,15 @@ namespace nanoFramework.Device.Bluetooth.Services
         /// <summary>
         /// Create a test service
         /// </summary>
-        /// <param name="provider"></param>
-        public TestService(GattServiceProvider provider)
+        public TestService()
         {
-            // Add new test  Service to provider
-            _testService = provider.AddService(serviceUUID);
+            GattServiceProviderResult pr = GattServiceProvider.Create(serviceUUID);
+            if (pr.Error != BluetoothError.Success)
+            {
+                throw new Exception("Unable to create service");
+            }
+
+            _testService = pr.ServiceProvider.Service;
 
             GattLocalCharacteristicParameters rxCommandPar = new GattLocalCharacteristicParameters()
             {

--- a/Tests/Client/Services/TestService.cs
+++ b/Tests/Client/Services/TestService.cs
@@ -40,7 +40,7 @@ namespace nanoFramework.Device.Bluetooth.Services
                 CharacteristicProperties = GattCharacteristicProperties.Write | GattCharacteristicProperties.WriteWithoutResponse
             };
 
-            GattLocalCharacteristicResult rxCommandRes = provider.Service.CreateCharacteristic(rxCommandUUID, rxCommandPar);
+            GattLocalCharacteristicResult rxCommandRes = pr.ServiceProvider.Service.CreateCharacteristic(rxCommandUUID, rxCommandPar);
             if (rxCommandRes.Error != nanoFramework.Device.Bluetooth.BluetoothError.Success)
             {
                 throw new ArgumentException("Unable to create RX Command");

--- a/Tests/NFUnitTest1/UnitTest1.cs
+++ b/Tests/NFUnitTest1/UnitTest1.cs
@@ -21,12 +21,12 @@ namespace NFUnitTest1
             GattServiceProvider serviceProvider;
 
             GattServiceProviderResult result = GattServiceProvider.Create(ServiceUuid1);
-            Assert.False(result.Error == BluetoothError.Success);
+            Assert.IsFalse(result.Error == BluetoothError.Success);
 
             serviceProvider = result.ServiceProvider;
-            Assert.Null(serviceProvider, "Service provider is null");
+            Assert.IsNull(serviceProvider, "Service provider is null");
 
-            Assert.True(serviceProvider.AdvertisementStatus == GattServiceProviderAdvertisementStatus.Stopped, "Advertisement status should be stopped");
+            Assert.IsTrue(serviceProvider.AdvertisementStatus == GattServiceProviderAdvertisementStatus.Stopped, "Advertisement status should be stopped");
         }
     }
 }

--- a/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
@@ -10,8 +10,8 @@ namespace nanoFramework.Device.Bluetooth
     /// </summary>
     public class BluetoothAddress
     {
-        private ulong _address;
-        private BluetoothAddressType _addressType;
+        private readonly ulong _address;
+        private readonly BluetoothAddressType _addressType;
 
         /// <summary>
         /// BluetoothAddress constructor.

--- a/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
@@ -6,7 +6,7 @@
 namespace nanoFramework.Device.Bluetooth
 {
     /// <summary>
-    /// Bluetooth Address object
+    /// Bluetooth Address class.
     /// </summary>
     public class BluetoothAddress
     {
@@ -14,10 +14,10 @@ namespace nanoFramework.Device.Bluetooth
         private BluetoothAddressType _addressType;
 
         /// <summary>
-        /// BluetoothAddress constructor
+        /// BluetoothAddress constructor.
         /// </summary>
-        /// <param name="Address">Bluetooth address </param>
-        /// <param name="AddressType">Bluetooth Address type</param>
+        /// <param name="Address">Bluetooth address.</param>
+        /// <param name="AddressType">Bluetooth Address type.</param>
         public BluetoothAddress(ulong Address, BluetoothAddressType AddressType)
         {
             _address = Address;
@@ -25,13 +25,13 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        /// Get Bluetouth address.
+        /// Get Bluetooth address.
         /// </summary>
-        public ulong Address { get { return _address; } }
+        public ulong Address { get => _address; }
 
         /// <summary>
-        /// Get Bluetooth type.
+        /// Gets Bluetooth type.
         /// </summary>
-        public BluetoothAddressType AddressType { get { return _addressType; } }
+        public BluetoothAddressType AddressType { get => _addressType; }
     }
 }

--- a/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothAddress.cs
@@ -1,0 +1,37 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Bluetooth Address object
+    /// </summary>
+    public class BluetoothAddress
+    {
+        private ulong _address;
+        private BluetoothAddressType _addressType;
+
+        /// <summary>
+        /// BluetoothAddress constructor
+        /// </summary>
+        /// <param name="Address">Bluetooth address </param>
+        /// <param name="AddressType">Bluetooth Address type</param>
+        public BluetoothAddress(ulong Address, BluetoothAddressType AddressType)
+        {
+            _address = Address;
+            _addressType = AddressType;
+        }
+
+        /// <summary>
+        /// Get Bluetouth address.
+        /// </summary>
+        public ulong Address { get { return _address; } }
+
+        /// <summary>
+        /// Get Bluetooth type.
+        /// </summary>
+        public BluetoothAddressType AddressType { get { return _addressType; } }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/BluetoothEvent.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEvent.cs
@@ -11,22 +11,22 @@ namespace nanoFramework.Device.Bluetooth
     internal class BluetoothEventServer : BaseEvent
     {
         /// <summary>
-        /// Type of Bluetooth event
+        /// Type of Bluetooth event.
         /// </summary>
         public BluetoothEventType type;
 
         /// <summary>
-        /// Event or Connect id
+        /// Event or Connect id.
         /// </summary>
         public ushort id;
 
         /// <summary>
-        /// id of Characteristic
+        /// id of Characteristic.
         /// </summary>
         public ushort characteristicId;
 
         /// <summary>
-        /// id of Descriptor
+        /// id of Descriptor.
         /// </summary>
         public ushort descriptorId;
     }
@@ -34,12 +34,12 @@ namespace nanoFramework.Device.Bluetooth
     internal class BluetoothEventScan : BaseEvent
     {
         /// <summary>
-        /// Type of Bluetooth event
+        /// Type of Bluetooth event.
         /// </summary>
         public BluetoothEventType type;
 
         /// <summary>
-        /// Event id
+        /// Event id.
         /// </summary>
         public ushort id;
     }
@@ -47,27 +47,27 @@ namespace nanoFramework.Device.Bluetooth
     internal class BluetoothEventCentral : BaseEvent
     {
         /// <summary>
-        /// Type of Bluetooth event
+        /// Type of Bluetooth event.
         /// </summary>
         public BluetoothEventType type;
 
         /// <summary>
-        /// Connection Handle
+        /// Connection Handle.
         /// </summary>
         public ushort connectionHandle;
 
         /// <summary>
-        /// status of event
+        /// status of event.
         /// </summary>
         public ushort status;
 
         /// <summary>
-        /// Attribute Handle of service
+        /// Attribute Handle of service.
         /// </summary>
         public ushort serviceHandle;
 
         /// <summary>
-        /// Attribute Handle of characteristic
+        /// Attribute Handle of characteristic.
         /// </summary>
         public ushort characteristicHandle;
     }
@@ -75,29 +75,28 @@ namespace nanoFramework.Device.Bluetooth
     internal class BluetoothEventSesssion : BaseEvent
     {
         /// <summary>
-        /// Type of Bluetooth event
+        /// Type of Bluetooth event.
         /// </summary>
         public BluetoothEventType type;
 
         /// <summary>
-        /// Connection Handle
+        /// Connection Handle.
         /// </summary>
         public ushort connectionHandle;
 
         /// <summary>
-        /// status of event
+        /// status of event.
         /// </summary>
         public ushort status;
 
         /// <summary>
-        /// Any extra data
+        /// Any extra data.
         /// </summary>
         public ushort data;
 
         /// <summary>
-        /// Used for when 32 bit data supplied (pin)
+        /// Used for when 32 bit data supplied (pin).
         /// </summary>
         public UInt32 data32;
-
     }
 }

--- a/nanoFramework.Device.Bluetooth/BluetoothEvent.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEvent.cs
@@ -6,9 +6,9 @@
 using System;
 using nanoFramework.Runtime.Events;
 
-namespace nanoFramework.Device.Bluetooth 
+namespace nanoFramework.Device.Bluetooth
 {
-    internal class BluetoothEventClient : BaseEvent
+    internal class BluetoothEventServer : BaseEvent
     {
         /// <summary>
         /// Type of Bluetooth event
@@ -72,4 +72,32 @@ namespace nanoFramework.Device.Bluetooth
         public ushort characteristicHandle;
     }
 
+    internal class BluetoothEventSesssion : BaseEvent
+    {
+        /// <summary>
+        /// Type of Bluetooth event
+        /// </summary>
+        public BluetoothEventType type;
+
+        /// <summary>
+        /// Connection Handle
+        /// </summary>
+        public ushort connectionHandle;
+
+        /// <summary>
+        /// status of event
+        /// </summary>
+        public ushort status;
+
+        /// <summary>
+        /// Any extra data
+        /// </summary>
+        public ushort data;
+
+        /// <summary>
+        /// Used for when 32 bit data supplied (pin)
+        /// </summary>
+        public UInt32 data32;
+
+    }
 }

--- a/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
@@ -25,10 +25,6 @@ namespace nanoFramework.Device.Bluetooth
         // Used for routing server events
         private static readonly ArrayList _leDeviceMap = new();
 
-        // Map of Bluetooth connectionHandles to Pairing security objects.
-        // Used for routing security events
-        private static readonly ArrayList _securityMap = new();
-
         // Reference to current BluetoothLEAdvertisementWatcher for events posting
         private static BluetoothLEAdvertisementWatcher _watcher = null;
 
@@ -309,42 +305,6 @@ namespace nanoFramework.Device.Bluetooth
         #region Session routing
         public BluetoothLEServer BluetoothServer { get => _server; set => _server = value; }
 
-        //public void AddSecurity(Pairing s)
-        //{
-        //    lock (_securityMap)
-        //    {
-        //        if (!_securityMap.Contains(s))
-        //        {
-        //            _securityMap.Add(s);
-        //        }
-        //        else
-        //        {
-        //        }
-        //    }
-        //}
-        //public void RemoveSecurity(Pairing s)
-        //{
-        //    lock (_securityMap)
-        //    {
-        //        if (_securityMap.Contains(s))
-        //        {
-        //            _securityMap.Remove(s);
-        //        }
-        //    }
-        //}
-
-        //public Pairing FindSecurity(ushort connectionHandle)
-        //{
-        //    for (int i = 0; i < _securityMap.Count; i++)
-        //    {
-        //        if (((Pairing)_securityMap[i]).ConnectionHandle == connectionHandle)
-        //        {
-        //            return (Pairing)_securityMap[i];
-        //        }
-        //    }
-
-        //    return null;
-        //}
         #endregion
 
         #region Watcher Queue

--- a/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
@@ -15,12 +15,19 @@ namespace nanoFramework.Device.Bluetooth
 {
     internal class BluetoothEventListener : IEventProcessor, IEventListener
     {
+        // Current service provider
+        private static BluetoothLEServer _server;
+
         // Map of Bluetooth Characteristic numbers to GattLocalCharacteristic objects.
         private static readonly ArrayList _characteristicMap = new();
 
         // Map of Bluetooth connectionHandles to BluetoothLEDevice objects.
         // Used for routing server events
         private static readonly ArrayList _leDeviceMap = new();
+
+        // Map of Bluetooth connectionHandles to Pairing security objects.
+        // Used for routing security events
+        private static readonly ArrayList _securityMap = new();
 
         // Reference to current BluetoothLEAdvertisementWatcher for events posting
         private static BluetoothLEAdvertisementWatcher _watcher = null;
@@ -53,7 +60,7 @@ namespace nanoFramework.Device.Bluetooth
             if (BLEEventType < BluetoothEventType.AdvertisementDiscovered)
             {
 
-                return new BluetoothEventClient
+                return new BluetoothEventServer
                 {
                     // Data1, Data2 is packed by PostManagedEvent.
                     //
@@ -73,7 +80,7 @@ namespace nanoFramework.Device.Bluetooth
                     id = (ushort)(data2 & 0xffff)
                 };
             }
-            else
+            else if (BLEEventType < BluetoothEventType.ClientConnected)
             {
                 return new BluetoothEventCentral
                 {
@@ -88,6 +95,26 @@ namespace nanoFramework.Device.Bluetooth
                     status = (ushort)(data2 & 0x00ff)
                 };
             }
+            else
+            {
+                // Connection/Pairing & security events for client sessions
+                return new BluetoothEventSesssion
+                {
+                    // Data1, Data2 is packed by PostManagedEvent, so we need to unpack the high word.
+                    //
+                    // Data1  - HHHH00TT where H=Connection_Handle, TT = BluetoothEventType
+                    // Data2  - DDDDxxSS where  DD = data, SS = status(8 bits)
+                    // or 
+                    // Data2 = 32 bit for pins
+
+                    type = BLEEventType,
+                    connectionHandle = data1High,
+
+                    status = (ushort)(data2 & 0x00ff),
+                    data = (ushort)(data2 >> 16),
+                    data32 = data2
+                };
+            }
         }
 
         public void InitializeForEventSource()
@@ -96,7 +123,7 @@ namespace nanoFramework.Device.Bluetooth
             new Thread(WatcherEventQueueThread).Start();
         }
 
-        private bool OnEventClient(BluetoothEventClient btEvent)
+        private bool OnEventServer(BluetoothEventServer btEvent)
         {
             GattLocalCharacteristic lc = null;
 
@@ -104,48 +131,47 @@ namespace nanoFramework.Device.Bluetooth
             {
                 // Search for Characteristic using Characteristic id part of Id
                 lc = FindCharacteristic(btEvent.characteristicId);
-            }
 
-            // Avoid calling this under a lock to prevent a potential lock inversion.
-            if (lc != null)
-            {
-                switch (btEvent.type)
+                // Avoid calling this under a lock to prevent a potential lock inversion.
+                if (lc != null)
                 {
-                    case BluetoothEventType.Read:
-                        lc.OnReadRequested(btEvent.descriptorId, new GattReadRequestedEventArgs(btEvent.id, null));
-                        break;
+                    switch (btEvent.type)
+                    {
+                        case BluetoothEventType.Read:
+                            lc.OnReadRequested(btEvent.descriptorId, new GattReadRequestedEventArgs(btEvent.id, null));
+                            break;
 
-                    case BluetoothEventType.Write:
-                        lc.OnWriteRequested(btEvent.descriptorId, new GattWriteRequestedEventArgs(btEvent.id, null));
-                        break;
+                        case BluetoothEventType.Write:
+                            lc.OnWriteRequested(btEvent.descriptorId, new GattWriteRequestedEventArgs(btEvent.id, null));
+                            break;
 
-                    case BluetoothEventType.ClientSubscribed:
-                        {
-                            GattSession gs = GattSession.FromDeviceId(new BluetoothDeviceId(btEvent.id));
-                            GattSubscribedClient sc = new(gs);
-                            lc.OnSubscribedClientsChanged(true, sc);
-                        }
-                        break;
+                        case BluetoothEventType.ClientSubscribed:
+                            {
+                                GattSession gs = GattSession.FromDeviceId(new BluetoothDeviceId(btEvent.id));
+                                GattSubscribedClient sc = new(gs);
+                                lc.OnSubscribedClientsChanged(true, sc);
+                            }
+                            break;
 
-                    case BluetoothEventType.ClientUnsubscribed:
-                        {
-                            GattSession gs = GattSession.FromDeviceId(new BluetoothDeviceId(btEvent.id));
-                            GattSubscribedClient sc = new(gs);
-                            lc.OnSubscribedClientsChanged(false, sc);
-                        }
-                        break;
+                        case BluetoothEventType.ClientUnsubscribed:
+                            {
+                                GattSession gs = GattSession.FromDeviceId(new BluetoothDeviceId(btEvent.id));
+                                GattSubscribedClient sc = new(gs);
+                                lc.OnSubscribedClientsChanged(false, sc);
+                            }
+                            break;
+                    }
                 }
             }
 
             return true;
-
         }
 
         private bool OnEventScan(BluetoothEventScan btEvent)
         {
             // Process Watcher events on separate thread so events for central don't
             // get held up when trying to connect to device within a watcher event
-            lock(_watcherQueue)
+            lock (_watcherQueue)
             {
                 _watcherQueue.Enqueue(btEvent);
             }
@@ -153,7 +179,7 @@ namespace nanoFramework.Device.Bluetooth
             return true;
         }
 
-        private bool OnEventCentral(BluetoothEventCentral btEvent)
+        private bool OnEventClient(BluetoothEventCentral btEvent)
         {
             // Need to route to correct BluetoothLEDevice
             BluetoothLEDevice ledev = FindLeDevice(btEvent.connectionHandle);
@@ -162,11 +188,27 @@ namespace nanoFramework.Device.Bluetooth
             return true;
         }
 
+        private bool OnEventSession(BluetoothEventSesssion btEvent)
+        {
+            // Route session event to GattServiceProvider or BluetoothLeDevice
+            if (_server != null)
+            {
+                _server.OnEvent(btEvent);
+            }
+            else
+            {
+                BluetoothLEDevice ledev = FindLeDevice(btEvent.connectionHandle);
+                ledev?.OnEvent(btEvent);
+            }
+
+            return true;
+        }
+
         public bool OnEvent(BaseEvent ev)
         {
-            if (ev.GetType() == typeof(BluetoothEventClient))
+            if (ev.GetType() == typeof(BluetoothEventServer))
             {
-                return OnEventClient((BluetoothEventClient)ev);
+                return OnEventServer((BluetoothEventServer)ev);
             }
             else if (ev.GetType() == typeof(BluetoothEventScan))
             {
@@ -174,7 +216,11 @@ namespace nanoFramework.Device.Bluetooth
             }
             else if (ev.GetType() == typeof(BluetoothEventCentral))
             {
-                return OnEventCentral((BluetoothEventCentral)ev);
+                return OnEventClient((BluetoothEventCentral)ev);
+            }
+            else if (ev.GetType() == typeof(BluetoothEventSesssion))
+            {
+                return OnEventSession((BluetoothEventSesssion)ev);
             }
 
             // Not handled
@@ -221,7 +267,7 @@ namespace nanoFramework.Device.Bluetooth
             return null;
         }
 
-        public int LeDeviceCount { get => _leDeviceMap.Count;  }
+        public int LeDeviceCount { get => _leDeviceMap.Count; }
         #endregion
 
         #region Server characteristic routing
@@ -258,6 +304,50 @@ namespace nanoFramework.Device.Bluetooth
             return null;
         }
 
+        #endregion
+
+        #region Session routing
+        public BluetoothLEServer BluetoothServer { get => _server; set => _server = value; }
+
+        //public void AddSecurity(Pairing s)
+        //{
+        //    lock (_securityMap)
+        //    {
+        //        if (!_securityMap.Contains(s))
+        //        {
+        //            _securityMap.Add(s);
+        //        }
+        //        else
+        //        {
+        //        }
+        //    }
+        //}
+        //public void RemoveSecurity(Pairing s)
+        //{
+        //    lock (_securityMap)
+        //    {
+        //        if (_securityMap.Contains(s))
+        //        {
+        //            _securityMap.Remove(s);
+        //        }
+        //    }
+        //}
+
+        //public Pairing FindSecurity(ushort connectionHandle)
+        //{
+        //    for (int i = 0; i < _securityMap.Count; i++)
+        //    {
+        //        if (((Pairing)_securityMap[i]).ConnectionHandle == connectionHandle)
+        //        {
+        //            return (Pairing)_securityMap[i];
+        //        }
+        //    }
+
+        //    return null;
+        //}
+        #endregion
+
+        #region Watcher Queue
         // Run event on separate thread so as not to block event queue
         // This will allow connects to devices in the event thread and they don't just time out
         private void WatcherEventQueueThread()
@@ -269,7 +359,7 @@ namespace nanoFramework.Device.Bluetooth
             {
                 if (_watcherEvent.WaitOne())
                 {
-                    while(_watcherQueue.Count > 0)
+                    while (_watcherQueue.Count > 0)
                     {
                         lock (_watcherQueue)
                         {
@@ -294,6 +384,7 @@ namespace nanoFramework.Device.Bluetooth
             }
         }
         #endregion
+
     }
 }
 

--- a/nanoFramework.Device.Bluetooth/BluetoothEventType.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEventType.cs
@@ -9,39 +9,39 @@ using nanoFramework.Runtime.Events;
 namespace nanoFramework.Device.Bluetooth
 {
     /// <summary>
-    /// Event type for Bluetooth events coming from Native
+    /// Event type for Bluetooth events coming from Native.
     /// </summary>
     public enum BluetoothEventType
     {
         /// <summary>
-        /// Attribute Read
+        /// Attribute Read.
         /// </summary>
         Read,
 
         /// <summary>
-        /// Attribute write
+        /// Attribute write.
         /// </summary>
         Write,
 
         /// <summary>
-        /// Client Subscribed
+        /// Client Subscribed.
         /// </summary>
         ClientSubscribed,
 
         /// <summary>
-        /// Client unsubscribed or connection terminated
+        /// Client unsubscribed or connection terminated.
         /// </summary>
         ClientUnsubscribed,
 
         // ==== BLE Scanning Events ====
 
         /// <summary>
-        /// Advertisement discovered when scanning
+        /// Advertisement discovered when scanning.
         /// </summary>
         AdvertisementDiscovered,
 
         /// <summary>
-        /// Discovery Scan complete
+        /// Discovery Scan complete.
         /// </summary>
         ScanningComplete,
 
@@ -50,7 +50,7 @@ namespace nanoFramework.Device.Bluetooth
         // ==== BLE Central/Client events ====
 
         /// <summary>
-        /// Fires when native connect to device completes
+        /// Fires when native connect to device completes.
         /// </summary>
         ConnectComplete,
 
@@ -60,42 +60,42 @@ namespace nanoFramework.Device.Bluetooth
         ConnectionDisconnected,
 
         /// <summary>
-        /// A Service discovered for a connection
+        /// A Service discovered for a connection.
         /// </summary>
         ServiceDiscovered,
 
         /// <summary>
-        /// Service discovery has completed
+        /// Service discovery has completed.
         /// </summary>
         ServiceDiscoveryComplete,
 
         /// <summary>
-        /// A characteristic discovered on Service
+        /// A characteristic discovered on Service.
         /// </summary>
         CharacteristicDiscovered,
 
         /// <summary>
-        /// The characteristic discovery has completed / error
+        /// The characteristic discovery has completed / error.
         /// </summary>
         CharacteristicDiscoveryComplete,
 
         /// <summary>
-        /// A descriptor discovered on Characteristic
+        /// A descriptor discovered on Characteristic.
         /// </summary>
         DescriptorDiscovered,
 
         /// <summary>
-        /// The Descriptor discovery has completed / error
+        /// The Descriptor discovery has completed / error.
         /// </summary>
         DescriptorDiscoveryComplete,
 
         /// <summary>
-        /// Characteristic read value complete, status=error
+        /// Characteristic read value complete, status=error.
         /// </summary>
         AttributeReadValueComplete,
 
         /// <summary>
-        /// Attribute Write value completed, status = error
+        /// Attribute Write value completed, status = error.
         /// </summary>
         AttributeWriteValueComplete,
 
@@ -110,32 +110,32 @@ namespace nanoFramework.Device.Bluetooth
         // ====  Session / Pairing / Security group events ====
 
         /// <summary>
-        /// Event when client connects
+        /// Event when client connects.
         /// </summary>
         ClientConnected,
 
         /// <summary>
-        /// Event when client disconnects
+        /// Event when client disconnects.
         /// </summary>
         ClientDisconnected,
 
         /// <summary>
-        /// Event when session details updated
+        /// Event when session details are updated.
         /// </summary>
         ClientSessionChanged,
 
         /// <summary>
-        /// Fired when a passkey action is requested 
+        /// Event fired when a passkey action is requested.
         /// </summary>
         PassKeyActions,
 
         /// <summary>
-        /// Fired when a passkey action for numeric comparsion is requested 
+        /// Event Fired when a passkey action for numeric comparison is requested.
         /// </summary>
-        PassKeyActions_numcmp,
+        PassKeyActionsNumericComparison,
 
         /// <summary>
-        /// Fired when the Authentication has completed, security enabled or failed to enable
+        /// Event fired when the Authentication has completed, security enabled or failed to enable.
         /// </summary>
         AuthenticationComplete
     }

--- a/nanoFramework.Device.Bluetooth/BluetoothEventType.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEventType.cs
@@ -45,6 +45,8 @@ namespace nanoFramework.Device.Bluetooth
         /// </summary>
         ScanningComplete,
 
+        // Add further server events here >>>>>>
+
         // ==== BLE Central/Client events ====
 
         /// <summary>
@@ -100,7 +102,41 @@ namespace nanoFramework.Device.Bluetooth
         /// <summary>
         /// Fired when a value on connected device has changed, notify.
         /// </summary>
-        AttributeValueChanged
+        AttributeValueChanged,
 
+        // Add further central events here >>>>>>
+
+
+        // ====  Session / Pairing / Security group events ====
+
+        /// <summary>
+        /// Event when client connects
+        /// </summary>
+        ClientConnected,
+
+        /// <summary>
+        /// Event when client disconnects
+        /// </summary>
+        ClientDisconnected,
+
+        /// <summary>
+        /// Event when session details updated
+        /// </summary>
+        ClientSessionChanged,
+
+        /// <summary>
+        /// Fired when a passkey action is requested 
+        /// </summary>
+        PassKeyActions,
+
+        /// <summary>
+        /// Fired when a passkey action for numeric comparsion is requested 
+        /// </summary>
+        PassKeyActions_numcmp,
+
+        /// <summary>
+        /// Fired when the Authentication has completed, security enabled or failed to enable
+        /// </summary>
+        AuthenticationComplete
     }
 }

--- a/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
@@ -75,7 +75,7 @@ namespace nanoFramework.Device.Bluetooth
             _scanResults = new Hashtable();
 
             NativeStartAdvertisementWatcher((int)_scanningMode);
-            GenericAttributeProfile.GattServiceProvider._bluetoothEventManager.Watcher = this;
+            BluetoothLEServer._bluetoothEventManager.Watcher = this;
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace nanoFramework.Device.Bluetooth
         {
             _status = BluetoothLEAdvertisementWatcherStatus.Stopping;
 
-            GenericAttributeProfile.GattServiceProvider._bluetoothEventManager.Watcher = null;
+            BluetoothLEServer._bluetoothEventManager.Watcher = null;
 
             NativeStopAdvertisementWatcher();
 

--- a/nanoFramework.Device.Bluetooth/BluetoothLEDevice.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEDevice.cs
@@ -366,13 +366,10 @@ namespace nanoFramework.Device.Bluetooth
                                             //Debug.WriteLine($"# Access error - Start pairing");
 
                                             // Try to pair devices
-                                            var pres = Pairing.Pair();
+                                            Pairing.Pair();
 
-                                            //Debug.WriteLine($"# Pair result {pres.Status}");
-
-                                            // retry read
+                                             // retry read
                                             retryRead = true;
-
                                             continue;
                                         }
                                         break;

--- a/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
@@ -1,0 +1,267 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections;
+using nanoFramework.Device.Bluetooth;
+using nanoFramework.Device.Bluetooth.GenericAttributeProfile;
+using System.Diagnostics;
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Represents a Bluetooth LE Server.
+    /// </summary>
+    public class BluetoothLEServer : IDisposable
+    {
+        private bool disposedValue;
+        private DevicePairing _pairing;
+        private GattSession _session;
+
+        private static BluetoothLEServer _instance;
+        private static readonly object _lock = new object();
+
+        internal static readonly BluetoothEventListener _bluetoothEventManager = new();
+        internal static ArrayList _services = new();
+
+        static BluetoothLEServer()
+        {
+        }
+
+        /// <summary>
+        /// Returns BluetoothLEServer singleton instance.
+        /// </summary>
+        public static BluetoothLEServer Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_instance == null)
+                        {
+                            _instance = new BluetoothLEServer();
+                        }
+                    }
+                }
+                return _instance;
+            }
+        }
+
+        /// <summary>
+        /// Construct new Bluetooth Server using primary service UUID
+        /// </summary>
+        private BluetoothLEServer()
+        {
+            this.disposedValue = false;
+
+            Init();
+        }
+
+        private void Init()
+        {
+            _session = new GattSession(new BluetoothDeviceId(0));
+            _pairing = new DevicePairing(this);
+            _services = new();
+
+            _bluetoothEventManager.BluetoothServer = this;
+            _bluetoothEventManager.Reset();
+        }
+
+        /// <summary>
+        /// Server device name, defaults to 'nanoFramework'
+        /// </summary>
+        public String DeviceName { get => BluetoothNanoDevice.DeviceName; set => BluetoothNanoDevice.DeviceName = value; }
+
+        /// <summary>
+        /// Get GattSession aasoicated with this server.
+        /// </summary>
+        public GattSession Session { get => _session; }
+
+        #region Services
+
+        /// <summary>
+        /// Returns service provider with specifued UUID
+        /// </summary>
+        /// <param name="serviceUuid"></param>
+        /// <returns>return GattServiceProvider object or null if not found.</returns>
+        public GattServiceProvider GetServiceByUUID(Guid serviceUuid)
+        {
+            foreach (GattServiceProvider srvprov in _services)
+            {
+                if (srvprov.Service.Uuid.Equals(serviceUuid))
+                {
+                    return srvprov;
+                }
+            };
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get an array of all associated services providers for this Bluetooth LE Server.
+        /// </summary>
+        /// <remarks>
+        /// The primary service will be index 0 followed by the Device Information at index 1.
+        /// Any other Services added to server will follow these in the order they were created.
+        /// </remarks>
+        public GattServiceProvider[] Services { get { return (GattServiceProvider[])_services.ToArray(typeof(GattServiceProvider)); } }
+
+        #endregion
+
+        #region Security/Pairing
+
+        /// <summary>
+        /// Return Pairing object for handling Pairing.
+        /// </summary>
+        public DevicePairing Pairing { get => _pairing; }
+
+        /// <summary>
+        /// Evaulate all services and work out security requirements
+        /// </summary>
+        /// <returns>Minimum DevicePairingProtectionLevel for servcies/characteristics</returns>
+        private DevicePairingProtectionLevel EvaluateSecurityPairingRequirements()
+        {
+            DevicePairingProtectionLevel _minProtectionLevel = DevicePairingProtectionLevel.Default;
+
+            bool secureConnection = false;
+            bool authentication = false;
+
+            foreach (GattServiceProvider srvp in _services)
+            {
+                foreach (GattLocalCharacteristic chr in srvp.Service.Characteristics)
+                {
+                    if (chr.ReadProtectionLevel == GattProtectionLevel.EncryptionRequired ||
+                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
+                    {
+                        secureConnection = true;
+                    }
+
+                    if (chr.ReadProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
+                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
+                    {
+                        authentication = true;
+                    }
+                }
+            }
+
+            if (secureConnection)
+            {
+                _minProtectionLevel = DevicePairingProtectionLevel.Encryption;
+            }
+
+            if (authentication)
+            {
+                _minProtectionLevel = DevicePairingProtectionLevel.EncryptionAndAuthentication;
+            }
+
+            return _minProtectionLevel;
+        }
+
+        #endregion Security
+
+        /// <summary>
+        /// Start Bluetoth stack for server mode
+        /// If already running or in Client mode will give an InvalidOperation Exception.
+        /// </summary>
+        public void Start()
+        {
+            // Check and switch to server mode ( Stack Bluetooth stack )
+            BluetoothNanoDevice.CheckMode(BluetoothNanoDevice.Mode.Server);
+        }
+
+        /// <summary>
+        /// Stop Bluetooth server mode.
+        /// This stops the bluetooth stack but doesn't remove the current Services managed objects.
+        /// To remove these dispose the BluetoothLEServer instance.
+        /// </summary>
+        public void Stop()
+        {
+            // Check in Server mode and change if not
+            BluetoothNanoDevice.CheckMode(BluetoothNanoDevice.Mode.NotRunning);
+        }
+
+        /// <summary>
+        /// Route Bluetooth events
+        /// </summary>
+        /// <param name="btEvent"></param>
+        internal void OnEvent(BluetoothEventSesssion btEvent)
+        {
+            //Debug.WriteLine($"# BluetoothLEServer OnEvent, type:{btEvent.type} status:{btEvent.status}");
+
+            switch (btEvent.type)
+            {
+                case BluetoothEventType.ClientConnected:
+                case BluetoothEventType.ClientDisconnected:
+                    _session.OnEvent(btEvent);
+                    break;
+
+                case BluetoothEventType.ClientSessionChanged:
+                case BluetoothEventType.PassKeyActions:
+                case BluetoothEventType.PassKeyActions_numcmp:
+                case BluetoothEventType.AuthenticationComplete:
+                    Pairing.OnEvent(btEvent);
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                // Stop, ignore any exceptions
+                try
+                {
+                    Stop();
+                }
+                catch {}; 
+
+                if (disposing)
+                {
+
+                    _bluetoothEventManager.Reset();
+                    _bluetoothEventManager.BluetoothServer = null;
+
+                    _services = null;
+                    _instance = null;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~BluetoothLEServer()
+        {
+            Dispose(disposing: false);
+        }
+
+        /// <summary>
+        /// Dispose BluetoothLESever.  
+        /// Remove all managed objects used by BluetoothLESever.
+        /// </summary>
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(disposing: true);
+            // Suppress finalization.
+            System.GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
@@ -96,7 +96,7 @@ namespace nanoFramework.Device.Bluetooth
                 {
                     return srvprov;
                 }
-            };
+            }
 
             return null;
         }
@@ -217,7 +217,10 @@ namespace nanoFramework.Device.Bluetooth
                 {
                     Stop();
                 }
-                catch {}; 
+                catch 
+                { 
+                    // ignore any errors
+                }
 
                 if (disposing)
                 {

--- a/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
@@ -84,9 +84,9 @@ namespace nanoFramework.Device.Bluetooth
         #region Services
 
         /// <summary>
-        /// Returns service provider with specifued UUID.
+        /// Returns service provider with specified UUID.
         /// </summary>
-        /// <param name="serviceUuid"></param>
+        /// <param name="serviceUuid">UUID of the service to get.</param>
         /// <returns>The service with the UUID.</returns>
         public GattServiceProvider GetServiceByUUID(Guid serviceUuid)
         {

--- a/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
@@ -32,10 +32,10 @@ namespace nanoFramework.Device.Bluetooth
         internal static string DeviceName { get => _deviceName; set => _deviceName = value; }
 
         /// <summary>
-        /// Check if current mode otherwise switch to mode
+        /// Checks if current mode enabled otherwise switch to mode.
         /// </summary>
-        /// <param name="expectedMode"></param>
-        /// <exception cref="InvalidOperationException"></exception>
+        /// <param name="expectedMode">The expected mode.</param>
+        /// <exception cref="InvalidOperationException">When mode is unexpected. i.e switching directly from client to server modes.</exception>
         internal static void CheckMode(Mode expectedMode)
         {
             if (RunMode != expectedMode)
@@ -48,6 +48,7 @@ namespace nanoFramework.Device.Bluetooth
         /// <summary>
         /// Get/Set the current mode of the device.
         /// </summary>
+        /// <exception cref="InvalidOperationException">When mode is unexpected from NativeSetOperationMode.</exception>
         internal static Mode RunMode
         {
             get => _mode;

--- a/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
@@ -19,7 +19,7 @@ namespace nanoFramework.Device.Bluetooth
         internal enum Mode { NotRunning, Server, Client };
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private static string _deviceName = "";
+        private static string _deviceName = "nanoFramework";
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private static Mode _mode = Mode.NotRunning;
@@ -31,16 +31,18 @@ namespace nanoFramework.Device.Bluetooth
 
         internal static string DeviceName { get => _deviceName; set => _deviceName = value; }
 
+        /// <summary>
+        /// Check if current mode otherwise switch to mode
+        /// </summary>
+        /// <param name="expectedMode"></param>
+        /// <exception cref="InvalidOperationException"></exception>
         internal static void CheckMode(Mode expectedMode)
         {
-            if (BluetoothNanoDevice.RunMode != expectedMode &&
-                BluetoothNanoDevice.RunMode != Mode.NotRunning)
+            if (RunMode != expectedMode)
             {
-                throw new InvalidOperationException("Wrong state");
+                // Set new run mode. 
+                BluetoothNanoDevice.RunMode = expectedMode;
             }
-
-            // Set new run mode. 
-            BluetoothNanoDevice.RunMode = expectedMode;
         }
 
         /// <summary>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristic.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristic.cs
@@ -281,7 +281,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             get => _protectionLevel;
             set
             {
-                // TODO - add security
                 _protectionLevel = value;
             }
         }

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
@@ -114,7 +114,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             }
 
             // Register with Events
-            GattServiceProvider._bluetoothEventManager.AddCharacteristic(this);
+            BluetoothLEServer._bluetoothEventManager.AddCharacteristic(this);
         }
 
         private static ushort NextCharacteristicIndex()

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalCharacteristic.cs
@@ -156,6 +156,10 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             {
                 decriptor = new GattLocalDescriptor(descriptorUuid, parameters, this, _descriptorNextID++);
                 _descriptors.Add(decriptor);
+
+                // Update pairing security based on current read/write protectionlevels.
+                BluetoothLEServer.Instance.UpdateSecurityPairingRequirements(decriptor.ReadProtectionLevel);
+                BluetoothLEServer.Instance.UpdateSecurityPairingRequirements(decriptor.WriteProtectionLevel);
             }
 
             return new GattLocalDescriptorResult(decriptor, result);

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalService.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattLocalService.cs
@@ -33,6 +33,10 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             GattLocalCharacteristic Characteristic = new(characteristicUuid, parameters);
             _characteristics.Add(Characteristic);
 
+            // Update pairing security based on current read/write protectionlevels.
+            BluetoothLEServer.Instance.UpdateSecurityPairingRequirements(Characteristic.ReadProtectionLevel);
+            BluetoothLEServer.Instance.UpdateSecurityPairingRequirements(Characteristic.WriteProtectionLevel);
+
             return new GattLocalCharacteristicResult(Characteristic, BluetoothError.Success);
         }
 

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -115,59 +115,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             }
         }
 
-        #region Security
-
-        /// <summary>
-        /// Evaulate all services and work out default security requirements.
-        /// </summary>
-        /// <returns>
-        /// Minimum DevicePairingProtectionLevel for servcies/characteristics.
-        /// </returns>
-        private DevicePairingProtectionLevel EvaluateSecurityPairingRequirements()
-        {
-            DevicePairingProtectionLevel _minProtectionLevel = DevicePairingProtectionLevel.Default;
-
-            bool secureConnection = false;
-            bool authentication = false;
-
-            foreach (GattLocalService srv in BluetoothLEServer._services)
-            {
-                foreach (GattLocalCharacteristic chr in srv.Characteristics)
-                {
-                    if (chr.ReadProtectionLevel == GattProtectionLevel.EncryptionRequired ||
-                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
-                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionRequired ||
-                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
-                    {
-                        secureConnection = true;
-                    }
-
-                    if (chr.ReadProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
-                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
-                        chr.WriteProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
-                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
-                    {
-                        authentication = true;
-                    }
-                }
-            }
-
-            if (secureConnection)
-            {
-                _minProtectionLevel = DevicePairingProtectionLevel.Encryption;
-            }
-
-            if (authentication)
-            {
-                _minProtectionLevel = DevicePairingProtectionLevel.EncryptionAndAuthentication;
-            }
-
-            return _minProtectionLevel;
-        }
-
-        #endregion Security
-
-
         /// <summary>
         ///  Stops advertising the current GATT service.
         /// </summary>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Collections;
 using System.Runtime.CompilerServices;
 using nanoFramework.Runtime.Native;
+using nanoFramework.Device.Bluetooth;
 
 namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 {
@@ -16,12 +17,10 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
     /// </summary>
     public class GattServiceProvider
     {
-        private  ArrayList _services;
-
         GattServiceProviderAdvertisementStatus _status = GattServiceProviderAdvertisementStatus.Created;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private byte[] _deviceName;
+        private GattLocalService _service;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private bool _isDiscoverable = true;
@@ -31,23 +30,20 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private Buffer _serviceData;
-
-
-        internal static readonly BluetoothEventListener _bluetoothEventManager = new();
-
+       
         internal GattServiceProvider(Guid serviceUuid)
         {
-            _bluetoothEventManager.Reset();
+            // Add local service
+            _service = new(serviceUuid);
 
-            _services = new ArrayList();
+            // Update services array
+            UpdateServices(this);
 
-            // Add primary
-            AddService(serviceUuid);
-
-            // Add default Device Information service 
-            AddDeviceInformationService();
-
-            NativeInitService();
+            // Add default Device Information service after first service added
+            if (BluetoothLEServer._services.Count == 1)
+            {
+                AddDeviceInformationService();
+            }
         }
 
         /// <summary>
@@ -56,7 +52,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         private void AddDeviceInformationService()
         {
             // Add and initialised Device Information defaults
-            GattLocalService dinfService = AddService(GattServiceUuids.DeviceInformation);
+            GattServiceProvider ServiceProvider = new GattServiceProvider(GattServiceUuids.DeviceInformation);
+            GattLocalService dinfService = ServiceProvider.Service;
 
             // ManufacturerNameString Characteristic (0x2A29)
             DataWriter manufacturerName = new();
@@ -96,30 +93,85 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public void StartAdvertising(GattServiceProviderAdvertisingParameters parameters)
         {
             // Check and switch to server mode
-            BluetoothNanoDevice.CheckMode(BluetoothNanoDevice.Mode.Server);
-
-            BluetoothNanoDevice.DeviceName = parameters.DeviceName;
+            if (BluetoothNanoDevice.RunMode != BluetoothNanoDevice.Mode.Server )
+            {
+                BluetoothLEServer.Instance.Start();
+            }
 
             // Save parameters
             _isConnectable = parameters.IsConnectable;
             _isDiscoverable = parameters.IsDiscoverable;
             _serviceData = parameters.ServiceData;
 
-            _deviceName = Encoding.UTF8.GetBytes(parameters.DeviceName);
+            // Make sure pairing attributes set
+            BluetoothLEServer.Instance.Pairing.SetPairAttributes();
 
             // Start advertising.
             // Native code will use the data provided by this GattServiceProvider instance to
             // initialise the BLE advert, service and characteristic definitions.
-            if (NativeStartAdvertising())
+            if (NativeStartAdvertising(BluetoothLEServer._services))
             {
                 _status = GattServiceProviderAdvertisementStatus.Started;
             }
         }
 
+        #region Security
+
         /// <summary>
-        ///  Stop advertising the GATT service.
+        /// Evaulate all services and work out default security requirements.
         /// </summary>
-        public void StopAdvertising()
+        /// <returns>
+        /// Minimum DevicePairingProtectionLevel for servcies/characteristics.
+        /// </returns>
+        private DevicePairingProtectionLevel EvaluateSecurityPairingRequirements()
+        {
+            DevicePairingProtectionLevel _minProtectionLevel = DevicePairingProtectionLevel.Default;
+
+            bool secureConnection = false;
+            bool authentication = false;
+
+            foreach (GattLocalService srv in BluetoothLEServer._services)
+            {
+                foreach (GattLocalCharacteristic chr in srv.Characteristics)
+                {
+                    if (chr.ReadProtectionLevel == GattProtectionLevel.EncryptionRequired ||
+                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
+                    {
+                        secureConnection = true;
+                    }
+
+                    if (chr.ReadProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
+                        chr.ReadProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.AuthenticationRequired ||
+                        chr.WriteProtectionLevel == GattProtectionLevel.EncryptionAndAuthenticationRequired)
+                    {
+                        authentication = true;
+                    }
+                }
+            }
+
+            if (secureConnection)
+            {
+                _minProtectionLevel = DevicePairingProtectionLevel.Encryption;
+            }
+
+            if (authentication)
+            {
+                _minProtectionLevel = DevicePairingProtectionLevel.EncryptionAndAuthentication;
+            }
+
+            return _minProtectionLevel;
+        }
+
+        #endregion Security
+
+
+        /// <summary>
+        ///  Stop advertising the current GATT service.
+        /// </summary>
+        internal void StopAdvertising()
         {
             // Stop advertising and dispose of native data.
             NativeStopAdvertising();
@@ -148,54 +200,30 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public GattServiceProviderAdvertisementStatus AdvertisementStatus { get => _status; }
 
         /// <summary>
-        /// Gets the GATT primary service.
+        /// Gets the GATT local service for this provider.
         /// </summary>
-        /// <returns>The primary service.</returns>
-        public GattLocalService Service { get => Services[0]; }
+        /// <returns>The GattLocalService object.</returns>
+        public GattLocalService Service { get => _service; }
 
-        /// <summary>
-        /// Get an array of all associated services for this service provider.
-        /// </summary>
-        /// <remarks>
-        /// The primary service will be index 0 followed by the Device Information at index 1.
-        /// Any other Services added to provider will follow these in the order they were created.
-        /// </remarks>
-        public GattLocalService[] Services { get { return (GattLocalService[])_services.ToArray(typeof(GattLocalService)); } }
-
-        /// <summary>
-        /// Creates a new service or replaces an existing service.
-        /// Created service is added to this service provider.
-        /// </summary>
-        /// <param name="serviceUuid">Uuid for the service to be created/replaced.</param>
-        /// <returns>
-        /// Returns the created service.
-        /// </returns>
-        public GattLocalService AddService(Guid serviceUuid)
+        private void UpdateServices(GattServiceProvider sprov)
         {
-            for (int index = 0; index < _services.Count; index++)
+            for (int index = 0; index < BluetoothLEServer._services.Count; index++)
             {
-                if (((GattLocalService)_services[index]).Uuid.Equals(serviceUuid))
+                // Service provider with same UUID then replace
+                if (((GattServiceProvider)BluetoothLEServer._services[index]).Service.Uuid.Equals(sprov._service.Uuid))
                 {
                     // Replace existing service on index
-                    GattLocalService replacementService = new(serviceUuid);
-                    _services[index] = replacementService;
-                    return replacementService;
+                    BluetoothLEServer._services[index] = sprov;
                 }
             }
 
-            // Add new service
-            GattLocalService newService = new(serviceUuid);
-            _services.Add(newService);
-            return newService;
+            BluetoothLEServer._services.Add(sprov);
         }
 
         #region external calls to native implementations
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool NativeInitService();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool NativeStartAdvertising();
+        private extern bool NativeStartAdvertising(ArrayList services);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void NativeStopAdvertising();

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -47,7 +47,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         }
 
         /// <summary>
-        /// Add default Device Information Service
+        /// Add default Device Information Service.
         /// </summary>
         private void AddDeviceInformationService()
         {
@@ -169,7 +169,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 
 
         /// <summary>
-        ///  Stop advertising the current GATT service.
+        ///  Stops advertising the current GATT service.
         /// </summary>
         internal void StopAdvertising()
         {
@@ -182,7 +182,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         }
 
         /// <summary>
-        ///  Creates a new GATT service with the specified serviceUuid
+        ///  Creates a new GATT service with the specified serviceUuid.
         /// </summary>
         /// <param name="serviceUuid">The service UUID.</param>
         /// <returns>A GattServiceProviderResult object.</returns>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProviderAdvertisingParameters.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProviderAdvertisingParameters.cs
@@ -12,10 +12,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
     /// </summary>
     public class GattServiceProviderAdvertisingParameters
     {
-        const string _defaultDeviceName = "nanoFramework";
-
-        private string _deviceName = _defaultDeviceName;
-
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private bool _isDiscoverable = true;
 
@@ -41,26 +37,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// Gets or sets a boolean that indicates if the GATT service is connect-able.
         /// </summary>
         public bool IsConnectable { get => _isConnectable; set => _isConnectable = value; }
-
-        /// <summary>
-        /// Friendly device name used for advertising service.
-        /// Default "nanoFramework"
-        /// </summary>
-        public string DeviceName
-        {
-            get => _deviceName;
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    _deviceName = _defaultDeviceName;
-                }
-                else
-                {
-                    _deviceName = value;
-                }
-            }
-        }
 
         /// <summary>
         /// For Bluetooth Low Energy, this parameter adds an additional **ServiceData** section

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
@@ -19,8 +19,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// <summary>
         /// Delegate for SessionStatusChanged events.
         /// </summary>
-        /// <param name="sender">GattSession sending event</param>
-        /// <param name="args">Event arguments</param>
+        /// <param name="sender">GattSession sending event.</param>
+        /// <param name="args">Event arguments.</param>
         public delegate void GattSessionStatusChangedEventHandler(Object sender, GattSessionStatusChangedEventArgs args);
 
         /// <summary>
@@ -29,7 +29,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public event GattSessionStatusChangedEventHandler SessionStatusChanged;
 
         /// <summary>
-        /// Maximum MTU size changed event
+        /// An event that is raised when the maximum protocol data unit (PDU) size changes. 
+        /// The PDU is also known as the maximum transmission unit (MTU).
         /// </summary>
         public event EventHandler MaxPduSizeChanged; 
 
@@ -76,7 +77,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public BluetoothDeviceId DeviceId { get => _deviceId; }
 
         /// <summary>
-        /// Gets the current Max PDU size.
+        /// Gets the maximum protocol data unit (PDU) size. 
+        /// This metric is also known as the maximum transmission unit (MTU) size.
         /// </summary>
         public ushort MaxPduSize { get => _maxPduSize; }
 

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
@@ -4,23 +4,34 @@
 //
 
 using System;
+using System.Diagnostics;
 
 namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 {
     /// <summary>
     /// This class represents a GATT session.
     /// </summary>
-    public class GattSession : IDisposable
+    public class GattSession
     {
         private readonly BluetoothDeviceId _deviceId;
+        private ushort _maxPduSize;
 
         /// <summary>
-        /// Dispose GattSession object
+        /// Delegate for SessionStatusChanged events.
         /// </summary>
-        public void Dispose()
-        {
-            // not used yet
-        }
+        /// <param name="sender">GattSession sending event</param>
+        /// <param name="args">Event arguments</param>
+        public delegate void GattSessionStatusChangedEventHandler(Object sender, GattSessionStatusChangedEventArgs args);
+
+        /// <summary>
+        /// Session status change event.
+        /// </summary>
+        public event GattSessionStatusChangedEventHandler SessionStatusChanged;
+
+        /// <summary>
+        /// Maximum MTU size changed event
+        /// </summary>
+        public event EventHandler MaxPduSizeChanged; 
 
         /// <summary>
         /// Creates a new GattSession object from the specified deviceId.
@@ -37,9 +48,37 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             _deviceId = deviceId;
         }
 
+        internal void OnEvent(BluetoothEventSesssion btEvent)
+        {
+            //Debug.WriteLine($"# GattServiceProvider OnEvent, type:{btEvent.type} status:{btEvent.status}");
+
+            switch (btEvent.type)
+            {
+                case BluetoothEventType.ClientConnected:
+                    SessionStatusChanged?.Invoke(this, new GattSessionStatusChangedEventArgs(GattSessionStatus.Active, 0));
+                    break;
+
+                case BluetoothEventType.ClientDisconnected:
+                    SessionStatusChanged?.Invoke(this, new GattSessionStatusChangedEventArgs(GattSessionStatus.Closed, 0));
+                    break;
+
+                case BluetoothEventType.ClientSessionChanged:
+                    // Update maxpdu size in GattSession
+                    _maxPduSize = btEvent.data;
+                    MaxPduSizeChanged?.Invoke(this, EventArgs.Empty);
+                    break;
+            }
+        }
+
         /// <summary>
         /// Gets the device id.
         /// </summary>
         public BluetoothDeviceId DeviceId { get => _deviceId; }
+
+        /// <summary>
+        /// Gets the current Max PDU size.
+        /// </summary>
+        public ushort MaxPduSize { get => _maxPduSize; }
+
     }
 }

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
@@ -19,7 +19,6 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
             _bluetoothError = bluetoothError;
         }
 
-
         /// <summary>
         /// Gets the status of the GATT session.
         /// </summary>

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
+{
+    /// <summary>
+    /// This class represents the SessionStatusChanged event args.
+    /// </summary>
+    public class GattSessionStatusChangedEventArgs
+    {
+        private GattSessionStatus _status;
+        private BluetoothError _bluetoothError;
+
+        internal GattSessionStatusChangedEventArgs(GattSessionStatus status, BluetoothError bluetoothError)
+        {
+            _status = status;
+            _bluetoothError = bluetoothError;
+        }
+
+
+        /// <summary>
+        /// Gets the status of the GATT session.
+        /// </summary>
+        public GattSessionStatus Status { get => _status; }
+
+        /// <summary>
+        /// Gets the error of the GATT session.
+        /// </summary>
+        public BluetoothError Error { get => _bluetoothError; }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSessionStatusChangedEventArgs.cs
@@ -10,8 +10,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
     /// </summary>
     public class GattSessionStatusChangedEventArgs
     {
-        private GattSessionStatus _status;
-        private BluetoothError _bluetoothError;
+        private readonly GattSessionStatus _status;
+        private readonly BluetoothError _bluetoothError;
 
         internal GattSessionStatusChangedEventArgs(GattSessionStatus status, BluetoothError bluetoothError)
         {

--- a/nanoFramework.Device.Bluetooth/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Device.Bluetooth/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.2.0")]
+[assembly: AssemblyNativeVersion("100.0.3.0")]
 ////////////////////////////////////////////////////////////////
 
 

--- a/nanoFramework.Device.Bluetooth/SPP/NordicSpp.cs
+++ b/nanoFramework.Device.Bluetooth/SPP/NordicSpp.cs
@@ -102,9 +102,10 @@ namespace nanoFramework.Device.Bluetooth.Spp
         /// <returns></returns>
         public bool Start(string deviceName)
         {
+            BluetoothLEServer.Instance.DeviceName = deviceName;
+
             GattServiceProviderAdvertisingParameters advParameters = new GattServiceProviderAdvertisingParameters
             {
-                DeviceName = deviceName,
                 IsDiscoverable = true,
                 IsConnectable = true
             };

--- a/nanoFramework.Device.Bluetooth/Security/DeviceBonding.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DeviceBonding.cs
@@ -1,0 +1,52 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace nanoFramework.Device.Bluetooth.Security
+{
+    /// <summary>
+    /// Class to encapsulate the bond store access.
+    /// </summary>
+    public static class DeviceBonding
+    {
+        /// <summary>
+        /// Is passed bluetooth address bonded
+        /// </summary>
+        /// <param name="bluetoothAddress"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern bool IsBonded(ulong bluetoothAddress);
+
+        /// <summary>
+        /// Delete all stored bonds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern void DeleteAllBonds();
+
+        /// <summary>
+        /// Delete bond information for peer.
+        /// </summary>
+        /// <param name="peerbluetoothAddress">Bluetooth address of Peer</param>
+        /// <param name="addressType">Type of Bluetooth address</param>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern void DeleteBondForPeer(ulong peerbluetoothAddress, BluetoothAddressType addressType);
+
+        /// <summary>
+        /// Returns the number of stored bonds.
+        /// </summary>
+        /// <returns>Bond count.</returns>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern int Count();
+
+        /// <summary>
+        /// Get Bonding address for peer at index.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern ulong GetBondInformationAt(int index);
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DeviceBonding.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DeviceBonding.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Runtime.CompilerServices;
 
 namespace nanoFramework.Device.Bluetooth.Security
@@ -13,24 +14,24 @@ namespace nanoFramework.Device.Bluetooth.Security
     public static class DeviceBonding
     {
         /// <summary>
-        /// Is passed bluetooth address bonded
+        /// Check if bluetooth address bonded.
         /// </summary>
-        /// <param name="bluetoothAddress"></param>
-        /// <returns></returns>
+        /// <param name="bluetoothAddress">Bluetooth address to check.</param>
+        /// <returns>True if bonded.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool IsBonded(ulong bluetoothAddress);
 
         /// <summary>
-        /// Delete all stored bonds.
+        /// Deletes all stored bonds.
         /// </summary>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void DeleteAllBonds();
 
         /// <summary>
-        /// Delete bond information for peer.
+        /// Deletes bond information for peer.
         /// </summary>
-        /// <param name="peerbluetoothAddress">Bluetooth address of Peer</param>
-        /// <param name="addressType">Type of Bluetooth address</param>
+        /// <param name="peerbluetoothAddress">Peer's Bluetooth address.</param>
+        /// <param name="addressType">Type of Bluetooth address.</param>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void DeleteBondForPeer(ulong peerbluetoothAddress, BluetoothAddressType addressType);
 
@@ -44,8 +45,10 @@ namespace nanoFramework.Device.Bluetooth.Security
         /// <summary>
         /// Get Bonding address for peer at index.
         /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
+        /// <param name="index">The index.</param>
+        /// <returns>The bonded address.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Index out range.</exception>
+        /// <exception cref="NotSupportedException">Bluetooth Stack is not running. run BluetoothLEServer.Start().</exception>        
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern ulong GetBondInformationAt(int index);
     }

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
@@ -18,11 +18,11 @@ namespace nanoFramework.Device.Bluetooth
     /// </summary>
     public sealed class DevicePairing
     {
-        BluetoothLEDevice _device = null;
-        BluetoothLEServer _server = null;
+        private readonly BluetoothLEDevice _device = null;
+        private readonly BluetoothLEServer _server = null;
         private readonly AutoResetEvent _completedEvent = new(false);
 
-        bool _canPair = true;
+        private readonly bool _canPair = true;
         bool _isPaired;
         bool _isAuthenticated;
 
@@ -260,9 +260,9 @@ namespace nanoFramework.Device.Bluetooth
 
                     _isPaired = (_pairingStatus == DevicePairingResultStatus.Paired);
 
-                    bool isEncrypted = (btEvent.data & 1) != 0;
+                    //bool isEncrypted = (btEvent.data & 1) != 0;
                     _isAuthenticated = (btEvent.data & 2) != 0;
-                    bool isBonded = (btEvent.data & 4) != 0;
+                    //bool isBonded = (btEvent.data & 4) != 0;
 
                     //Debug.WriteLine($"# Pairing AuthenticationComplete isPaired:{_isPaired} status:{btEvent.status} data:{btEvent.data} isEncrypted:{isEncrypted} isAuthenticated:{isAuthenticated} isBonded:{isBonded} ");
 

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
@@ -33,9 +33,6 @@ namespace nanoFramework.Device.Bluetooth
         // Protection level to use when pairing
         DevicePairingProtectionLevel _protectionLevel = DevicePairingProtectionLevel.None;
 
-        //// Use Secure connections by default
-        //private bool _secureConnections = true;
-        
         // Allow device to be bonded
         private bool _bondingAllowed;
 
@@ -50,25 +47,25 @@ namespace nanoFramework.Device.Bluetooth
         /// <summary>
         /// Delegate for Pairing requested events.
         /// </summary>
-        /// <param name="sender">Pairing class sending event</param>
-        /// <param name="args">Event arguments</param>
+        /// <param name="sender">Pairing class sending event.</param>
+        /// <param name="args">Event arguments.</param>
         public delegate void DevicePairingRequestedHandler(Object sender, DevicePairingRequestedEventArgs args);
 
         /// <summary>
         /// Delegate for Pairing Complete events.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="args"></param>
+        /// <param name="sender">Event sender.</param>
+        /// <param name="args">Device event arguments.</param>
         public delegate void PairingCompleteHandler(Object sender, DevicePairingEventArgs args);
 
         /// <summary>
-        /// Raised when a pairing action is requested.
+        /// Event raised when a pairing action is requested.
         /// </summary>
         public event DevicePairingRequestedHandler PairingRequested;
 
         /// <summary>
         /// Event fired when a Pairing has completed. Check status for succesful completion
-        /// and the IsPaired, IsAuthenticated
+        /// and the IsPaired, IsAuthenticated.
         /// </summary>
         public event PairingCompleteHandler PairingComplete;
 
@@ -114,16 +111,15 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        /// Use external method for exchange of information for pairing process.
+        /// True if uses external method for exchange of information for pairing process.
         /// Could be predefined info in device.
         /// Defaults to false.
         /// </summary>
         public bool OutOfBand { get => _outOfBand; set => _outOfBand = value; }
 
-
         /// <summary>
-        /// Protection level to be used for pairing.
-        /// The default value is set based on the protection level requirements in added characteristics.
+        /// Gets or sets protection level to be used for pairing.
+        /// The default value is set based on the protection level requirements in added characteristics and descriptors.
         /// </summary>
         public DevicePairingProtectionLevel ProtectionLevel 
         { 
@@ -135,9 +131,8 @@ namespace nanoFramework.Device.Bluetooth
             }
         }
 
-
         /// <summary>
-        /// Get / Set the IO capabilties of the device.
+        /// Gets or sets the IO capabilities of the device.
         /// By default the IO capabilties are set to NoInputNoOutput which will cause Unauthenicated Just Wroks pairing.
         /// </summary>
         public DevicePairingIOCapabilities IOCapabilities 
@@ -150,11 +145,10 @@ namespace nanoFramework.Device.Bluetooth
             }
         }
 
-
         /// <summary>
         /// Attempts to initiate a pairing of device using default protecion level.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The result of the device pairing action.</returns>
         public DevicePairingResult Pair()
         {
             return Pair(_protectionLevel);
@@ -192,7 +186,7 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        /// Unpair the device.
+        /// Unpairs the device.
         /// </summary>
         /// <returns>The result of the unpairing action.</returns>
         public DeviceUnpairingResult Unpair()
@@ -213,12 +207,12 @@ namespace nanoFramework.Device.Bluetooth
         public bool IsPaired { get => _isPaired; }
 
         /// <summary>
-        /// Returns if latest pairing was Authenicated.
+        /// Gets a value that indicates if latest pairing was Authenicated.
         /// </summary>
         public bool IsAuthenticated { get => _isAuthenticated; }
 
         /// <summary>
-        /// Set Pairing Attibutes in Native level
+        /// Sets Pairing Attibutes in Native level.
         /// </summary>
         internal void SetPairAttributes()
         {
@@ -226,9 +220,9 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        /// Internal event handler
+        /// Internal event handler.
         /// </summary>
-        /// <param name="btEvent"></param>
+        /// <param name="btEvent">The Bluetooth Event.</param>
         internal void OnEvent(BluetoothEventSesssion btEvent)
         {
             switch (btEvent.type)
@@ -240,27 +234,24 @@ namespace nanoFramework.Device.Bluetooth
 
                     OnEvent(btEvent, kind, 0);
 
-                    //    // None
-                    //        break;
+                    // == Input passkey ( paaskey displayed on other devicde ) ==
+                    // Enter Passkey by calling Accept with pin
+                    // Event must call -> Accept with passkey
 
-                    //    // == Input passkey ( paaskey displayed on other devicde ) ==
-                    //    // Enter Passkey by calling Accept with pin
-                    //    // Event must call -> Accept with passkey
+                    // Display action, Display passkey on current device so passkey can be entered on peer device. 
+                    // i.e. Set the Passkey to be entered on peer.
+                    // Event must call -> Accept with passkey
 
-                    //    // Display action, Display passkey on current device so passkey can be entered on peer device. 
-                    //    // i.e. Set the Passkey to be entered on peer.
-                    //    // Event must call -> Accept with passkey
+                    // Numbers displayed on both devices 
+                    // Numeric compare
+                    // Accept passkey is same as whats displayed on peer
+                    // Call Accept or ignore
 
-                    //    // Numbers displayed on both devices 
-                    //    // Numeric compare
-                    //    // Accept passkey is same as whats displayed on peer
-                    //    // Call Accept or ignore
-
-                    //    // Out of band (Not implemented)
-                    //    // Accept by calling Accept with Password Credentials
+                    // Out of band (Not implemented)
+                    // Accept by calling Accept with Password Credentials
                     break;
 
-                case BluetoothEventType.PassKeyActions_numcmp:
+                case BluetoothEventType.PassKeyActionsNumericComparison:
                     OnEvent(btEvent, DevicePairingKinds.ConfirmPinMatch, btEvent.data32);
                     break;
 
@@ -279,12 +270,10 @@ namespace nanoFramework.Device.Bluetooth
                     _completedEvent.Set();
 
                     PairingComplete?.Invoke(this, new DevicePairingEventArgs(btEvent.connectionHandle, _pairingStatus));
-
                     break;
 
                 default:
                     break;
-
             }
         }
 

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairing.cs
@@ -1,0 +1,306 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.Device.Bluetooth.GenericAttributeProfile;
+using nanoFramework.Device.Bluetooth.Security;
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Contains information and enables pairing for a device.
+    /// </summary>
+    public sealed class DevicePairing
+    {
+        BluetoothLEDevice _device = null;
+        BluetoothLEServer _server = null;
+        private readonly AutoResetEvent _completedEvent = new(false);
+
+        bool _canPair = true;
+        bool _isPaired;
+        bool _isAuthenticated;
+
+        // IO Capibilities used for pairing
+        // Defualt to NoInputNoOutput
+        DevicePairingIOCapabilities _ioCapabilities = DevicePairingIOCapabilities.NoInputNoOutput;
+
+        // Protection level to use when pairing
+        DevicePairingProtectionLevel _protectionLevel = DevicePairingProtectionLevel.None;
+
+        //// Use Secure connections by default
+        //private bool _secureConnections = true;
+        
+        // Allow device to be bonded
+        private bool _bondingAllowed;
+
+        private DevicePairingResultStatus _pairingStatus;
+
+        // Use external method for information for pairing process. 
+        private bool _outOfBand = false;
+
+        // Time for Pairing to complete before reporting timeout
+        private const int operationPairTimeout = 10000;
+
+        /// <summary>
+        /// Delegate for Pairing requested events.
+        /// </summary>
+        /// <param name="sender">Pairing class sending event</param>
+        /// <param name="args">Event arguments</param>
+        public delegate void DevicePairingRequestedHandler(Object sender, DevicePairingRequestedEventArgs args);
+
+        /// <summary>
+        /// Delegate for Pairing Complete events.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        public delegate void PairingCompleteHandler(Object sender, DevicePairingEventArgs args);
+
+        /// <summary>
+        /// Raised when a pairing action is requested.
+        /// </summary>
+        public event DevicePairingRequestedHandler PairingRequested;
+
+        /// <summary>
+        /// Event fired when a Pairing has completed. Check status for succesful completion
+        /// and the IsPaired, IsAuthenticated
+        /// </summary>
+        public event PairingCompleteHandler PairingComplete;
+
+        internal DevicePairing(BluetoothLEDevice device)
+        {
+            _device = device;
+            Reset();
+        }
+
+        internal DevicePairing(BluetoothLEServer server)
+        {
+            _server = server;
+
+            Reset();
+
+            // Set default attributes in Native
+            SetPairAttributes();
+        }
+
+        internal void Reset()
+        {
+            _ioCapabilities = DevicePairingIOCapabilities.NoInputNoOutput;
+            _protectionLevel = DevicePairingProtectionLevel.None;
+            _isPaired = false;
+            _isAuthenticated = false;
+            _outOfBand = false;
+            _bondingAllowed = true;
+        }
+
+        /// <summary>
+        /// When true will allow device to be bonded.
+        /// See Bonding methods. 
+        /// Defaults to true. 
+        /// </summary>
+        public bool AllowBonding 
+        { 
+            get => _bondingAllowed; 
+            set
+            {
+                _bondingAllowed = value;
+                SetPairAttributes();
+            }
+        }
+
+        /// <summary>
+        /// Use external method for exchange of information for pairing process.
+        /// Could be predefined info in device.
+        /// Defaults to false.
+        /// </summary>
+        public bool OutOfBand { get => _outOfBand; set => _outOfBand = value; }
+
+
+        /// <summary>
+        /// Protection level to be used for pairing.
+        /// The default value is set based on the protection level requirements in added characteristics.
+        /// </summary>
+        public DevicePairingProtectionLevel ProtectionLevel 
+        { 
+            get => _protectionLevel;
+            set
+            { 
+                _protectionLevel = value;
+                SetPairAttributes();
+            }
+        }
+
+
+        /// <summary>
+        /// Get / Set the IO capabilties of the device.
+        /// By default the IO capabilties are set to NoInputNoOutput which will cause Unauthenicated Just Wroks pairing.
+        /// </summary>
+        public DevicePairingIOCapabilities IOCapabilities 
+        { 
+            get => _ioCapabilities;
+            set
+            { 
+                _ioCapabilities = value;
+                SetPairAttributes();
+            }
+        }
+
+
+        /// <summary>
+        /// Attempts to initiate a pairing of device using default protecion level.
+        /// </summary>
+        /// <returns></returns>
+        public DevicePairingResult Pair()
+        {
+            return Pair(_protectionLevel);
+        }
+
+        /// <summary>
+        /// Attempts to pair the device using a provided level of protection.
+        /// </summary>
+        /// <param name="minProtectionLevel">The required level of protection to use for the pairing action.</param>
+        /// <returns>The result of the pairing action.</returns>
+        public DevicePairingResult Pair(DevicePairingProtectionLevel minProtectionLevel)
+        {
+            _isPaired = false;
+
+            if (_server != null)
+            {
+                _server.Start();
+            }
+            else
+            {
+                _device.ConnectDeviceIfNotConnected();
+            }
+
+            SetPairAttributes();
+            
+            if (NativeStartPair(_device.ConnectionHandle) == 0)
+            { 
+                if (!_completedEvent.WaitOne(operationPairTimeout, false))
+                {
+                    _pairingStatus = DevicePairingResultStatus.AuthenticationTimeout;
+                }
+            }
+
+            return new DevicePairingResult(minProtectionLevel, _pairingStatus);
+        }
+
+        /// <summary>
+        /// Unpair the device.
+        /// </summary>
+        /// <returns>The result of the unpairing action.</returns>
+        public DeviceUnpairingResult Unpair()
+        {
+            return new DeviceUnpairingResult(0);
+        }
+
+        /// <summary>
+        ///  Gets a value that indicates whether the device can be paired.
+        ///  **True** if the device can be paired, otherwise **false**.
+        /// </summary>
+        public bool CanPair { get => _canPair; }
+
+        /// <summary>
+        /// Gets a value that indicates whether the device is currently paired.
+        /// **True** if the device is currently paired, otherwise **false**.
+        /// </summary>
+        public bool IsPaired { get => _isPaired; }
+
+        /// <summary>
+        /// Returns if latest pairing was Authenicated.
+        /// </summary>
+        public bool IsAuthenticated { get => _isAuthenticated; }
+
+        /// <summary>
+        /// Set Pairing Attibutes in Native level
+        /// </summary>
+        internal void SetPairAttributes()
+        {
+            NativeSetPairAttributes();
+        }
+
+        /// <summary>
+        /// Internal event handler
+        /// </summary>
+        /// <param name="btEvent"></param>
+        internal void OnEvent(BluetoothEventSesssion btEvent)
+        {
+            switch (btEvent.type)
+            {
+                case BluetoothEventType.PassKeyActions:
+                    DevicePairingKinds kind = (DevicePairingKinds)btEvent.data;
+
+                    // Debug.WriteLine($"# Pairing DevicePairingKinds:{kind} status:{btEvent.status}");
+
+                    OnEvent(btEvent, kind, 0);
+
+                    //    // None
+                    //        break;
+
+                    //    // == Input passkey ( paaskey displayed on other devicde ) ==
+                    //    // Enter Passkey by calling Accept with pin
+                    //    // Event must call -> Accept with passkey
+
+                    //    // Display action, Display passkey on current device so passkey can be entered on peer device. 
+                    //    // i.e. Set the Passkey to be entered on peer.
+                    //    // Event must call -> Accept with passkey
+
+                    //    // Numbers displayed on both devices 
+                    //    // Numeric compare
+                    //    // Accept passkey is same as whats displayed on peer
+                    //    // Call Accept or ignore
+
+                    //    // Out of band (Not implemented)
+                    //    // Accept by calling Accept with Password Credentials
+                    break;
+
+                case BluetoothEventType.PassKeyActions_numcmp:
+                    OnEvent(btEvent, DevicePairingKinds.ConfirmPinMatch, btEvent.data32);
+                    break;
+
+                case BluetoothEventType.AuthenticationComplete:
+                    _pairingStatus = (DevicePairingResultStatus)btEvent.status;
+
+                    _isPaired = (_pairingStatus == DevicePairingResultStatus.Paired);
+
+                    bool isEncrypted = (btEvent.data & 1) != 0;
+                    _isAuthenticated = (btEvent.data & 2) != 0;
+                    bool isBonded = (btEvent.data & 4) != 0;
+
+                    //Debug.WriteLine($"# Pairing AuthenticationComplete isPaired:{_isPaired} status:{btEvent.status} data:{btEvent.data} isEncrypted:{isEncrypted} isAuthenticated:{isAuthenticated} isBonded:{isBonded} ");
+
+                    // Inform Pair operation Auth complete
+                    _completedEvent.Set();
+
+                    PairingComplete?.Invoke(this, new DevicePairingEventArgs(btEvent.connectionHandle, _pairingStatus));
+
+                    break;
+
+                default:
+                    break;
+
+            }
+        }
+
+        internal void OnEvent(BluetoothEventSesssion btEvent, DevicePairingKinds kind, uint pin)
+        {
+            PairingRequested?.Invoke(_device == null ? _server : _device, new DevicePairingRequestedEventArgs(this, btEvent.connectionHandle, kind, pin));
+        }
+
+        #region external calls to native implementations
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern ushort NativeStartPair(ushort connection);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeSetPairAttributes();
+
+        #endregion
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingEventArgs.cs
@@ -1,0 +1,31 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// This class contains the arguments for the Pairing Complete event.
+    /// </summary>
+    public class DevicePairingEventArgs
+    {
+        private readonly ushort _connectionHandle;
+        private readonly DevicePairingResultStatus _status;
+
+        internal DevicePairingEventArgs(ushort connectionHandle, DevicePairingResultStatus status)
+        {
+            _connectionHandle = connectionHandle;
+            _status = status;   
+        }
+
+        /// <summary>
+        /// Status code of Pairing operation.
+        /// </summary>
+        public DevicePairingResultStatus Status { get { return _status; } }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingIOCapabilities.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingIOCapabilities.cs
@@ -21,7 +21,7 @@ namespace nanoFramework.Device.Bluetooth
         DisplayYesNo = 1,
 
         /// <summary>
-        /// Device has keyboard
+        /// Device has keyboard.
         /// </summary>
         KeyboardOnly = 2,
 
@@ -32,10 +32,8 @@ namespace nanoFramework.Device.Bluetooth
         NoInputNoOutput = 3,
 
         /// <summary>
-        /// Decice has Keybaord and Display (input/Output)
+        /// Device has Keyboard and Display (input/Output).
         /// </summary>
         KeyboardDisplay = 4
     }
 }
-
-

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingIOCapabilities.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingIOCapabilities.cs
@@ -1,0 +1,41 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Kinds of IO capabilties used for pairing.
+    /// </summary>
+    public enum DevicePairingIOCapabilities
+    {
+        /// <summary>
+        /// Device has just a display.
+        /// </summary>
+        DisplayOnly = 0,
+
+        /// <summary>
+        /// Device can output numeric data and has a way to input a Yes or No (buttons).
+        /// </summary>
+        DisplayYesNo = 1,
+
+        /// <summary>
+        /// Device has keyboard
+        /// </summary>
+        KeyboardOnly = 2,
+
+        /// <summary>
+        /// Device has no output or input. 
+        /// All pairing uses Just Works.
+        /// </summary>
+        NoInputNoOutput = 3,
+
+        /// <summary>
+        /// Decice has Keybaord and Display (input/Output)
+        /// </summary>
+        KeyboardDisplay = 4
+    }
+}
+
+

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingKinds .cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingKinds .cs
@@ -1,0 +1,44 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Kinds of paring.
+    /// </summary>
+    public enum DevicePairingKinds
+    {
+        /// <summary>
+        /// No pairing is supported.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The application must confirm they wish to perform the pairing action. You can present an optional confirmation dialog to the user. 
+        /// With a value of ConfirmOnly, call Accept from the event args of the PairingRequested event handler if you want the pairing to complete.
+        /// </summary>
+        ConfirmOnly = 1,
+
+        /// <summary>
+        /// The application must display the given PIN to the user. The user will then need to enter or confirm that PIN on the device that is being paired. 
+        /// With a value of DisplayPin, call Accept from the event args of the PairingRequested event handler if you want the pairing to complete. 
+        /// If your application cancels the pairing at this point, the device might still be paired. This is because the system and the target 
+        /// device don't need any confirmation for this DevicePairingKinds value.
+        /// </summary>
+        DisplayPin = 2,
+
+        /// <summary>
+        /// The application must request a PIN from the user. The PIN will typically be displayed on the target device. With a value of ProvidePin, 
+        /// call Accept from the event args of the PairingRequested event handler if you want the pairing to complete. Pass in the PIN as a parameter.
+        /// </summary>
+        ProvidePin = 4,
+
+        /// <summary>
+        /// The application must display the given PIN to the user and ask the user to confirm that the PIN matches the one show on the target device. 
+        /// With a value of ConfirmPinMatch, call Accept from the event args of the PairingRequested event handler if you want the pairing to complete.
+        /// </summary>
+        ConfirmPinMatch = 8,
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingProtectionLevel.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingProtectionLevel.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// The level of protection for pairing.
+    /// </summary>
+    public enum DevicePairingProtectionLevel
+    {
+        /// <summary>
+        /// The default value. This should not be used.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Pair the device using no levels of protection.
+        /// </summary>
+        None = 1,
+
+        /// <summary>
+        /// Pair the device using encryption. 
+        /// </summary>
+        Encryption = 2,
+
+        /// <summary>
+        /// Pair the device using encryption and authentication.
+        /// </summary>
+        EncryptionAndAuthentication = 3
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
@@ -30,12 +30,12 @@ namespace nanoFramework.Device.Bluetooth
         /// <summary>
         /// Gets the kind of pairing associated with this pairing event.
         /// </summary>
-        public DevicePairingKinds PairingKind { get { return _kind; } }
+        public DevicePairingKinds PairingKind { get => _kind; }
 
         /// <summary>
         /// Gets the pin associated with a pairing request.
         /// </summary>
-        public uint Pin { get { return _pin; } }
+        public uint Pin { get => _pin; }
 
         /// <summary>
         /// Accepts a PairingRequested event and pairs the device with the application.
@@ -46,9 +46,10 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        ///  Accepts a PairingRequested event and pairs the device with the application. Requires a passkey for pairing purposes.
+        ///  Accepts a PairingRequested event and pairs the device with the application. 
+        ///  Requires a passkey for pairing purposes.
         /// </summary>
-        /// <param name="passkey"></param>
+        /// <param name="passkey">The pass key for pairing.</param>
         public void Accept(int passkey)
         {
             NativeAcceptPasskey(_connectionHandle, _kind,  passkey);
@@ -58,7 +59,7 @@ namespace nanoFramework.Device.Bluetooth
         /// Accepts a PairingRequested event and pairs the device with the application when
         /// a user name and password is required for pairing purposes.
         /// </summary>
-        /// <param name="password"></param>
+        /// <param name="password">The password credential.</param>
         public void AcceptWithPasswordCredential(PasswordCredential password)
         {
             NativeAcceptCredentials(_connectionHandle, _kind, Encoding.UTF8.GetBytes(password.UserName), Encoding.UTF8.GetBytes(password.Password));

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
@@ -1,0 +1,80 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// This class contains the arguments for the Pairing event.
+    /// </summary>
+    public class DevicePairingRequestedEventArgs
+    {
+        private readonly DevicePairing _pairing;
+        private readonly ushort _connectionHandle;
+        private readonly DevicePairingKinds _kind;
+        private uint _pin;
+
+        internal DevicePairingRequestedEventArgs(DevicePairing pairing, ushort connectionHandle, DevicePairingKinds kind, uint pin)
+        {
+            _pairing = pairing;
+            _connectionHandle = connectionHandle;
+            _kind = kind;
+            _pin = pin;
+        }
+
+        /// <summary>
+        /// Gets the kind of pairing associated with this pairing event.
+        /// </summary>
+        public DevicePairingKinds PairingKind { get { return _kind; } }
+
+        /// <summary>
+        /// Gets the pin associated with a pairing request.
+        /// </summary>
+        public uint Pin { get { return _pin; } }
+
+        /// <summary>
+        /// Accepts a PairingRequested event and pairs the device with the application.
+        /// </summary>
+        public void Accept()
+        {
+            NativeAcceptYesNo(_connectionHandle, _kind, 1);
+        }
+
+        /// <summary>
+        ///  Accepts a PairingRequested event and pairs the device with the application. Requires a passkey for pairing purposes.
+        /// </summary>
+        /// <param name="passkey"></param>
+        public void Accept(int passkey)
+        {
+            NativeAcceptPasskey(_connectionHandle, _kind,  passkey);
+        }
+
+        /// <summary>
+        /// Accepts a PairingRequested event and pairs the device with the application when
+        /// a user name and password is required for pairing purposes.
+        /// </summary>
+        /// <param name="password"></param>
+        public void AcceptWithPasswordCredential(PasswordCredential password)
+        {
+            NativeAcceptCredentials(_connectionHandle, _kind, Encoding.UTF8.GetBytes(password.UserName), Encoding.UTF8.GetBytes(password.Password));
+        }
+
+        #region external calls to native implementations
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern ushort NativeAcceptYesNo(ushort connectionHandle, DevicePairingKinds kind, int YesNo);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern ushort NativeAcceptPasskey(ushort connectionHandle, DevicePairingKinds kind, int passkey);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern ushort NativeAcceptCredentials(ushort connectionHandle, DevicePairingKinds kind, byte[] username, byte[] password);
+
+        #endregion
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingRequestedEventArgs.cs
@@ -17,7 +17,7 @@ namespace nanoFramework.Device.Bluetooth
         private readonly DevicePairing _pairing;
         private readonly ushort _connectionHandle;
         private readonly DevicePairingKinds _kind;
-        private uint _pin;
+        private readonly uint _pin;
 
         internal DevicePairingRequestedEventArgs(DevicePairing pairing, ushort connectionHandle, DevicePairingKinds kind, uint pin)
         {

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingResult.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingResult.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Contains information about the result of attempting to pair a device.
+    /// </summary>
+    public class DevicePairingResult 
+    {
+        private readonly DevicePairingProtectionLevel _protectionLevelUsed;
+        private readonly DevicePairingResultStatus _status;
+
+        internal DevicePairingResult(DevicePairingProtectionLevel protectionLevelUsed, DevicePairingResultStatus status)
+        {
+            _protectionLevelUsed = protectionLevelUsed;
+            _status = status;
+        }
+
+        /// <summary>
+        /// Gets the level of protection used to pair the device.
+        /// </summary>
+        public DevicePairingProtectionLevel ProtectionLevelUsed { get => _protectionLevelUsed; }
+
+         /// <summary>
+        /// Gets the paired status of the device after the pairing action completed.
+        /// </summary>
+        public DevicePairingResultStatus Status { get => _status; }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DevicePairingResultStatus.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DevicePairingResultStatus.cs
@@ -1,0 +1,117 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// The result of the pairing action.
+    /// </summary>
+    public enum DevicePairingResultStatus
+    {
+        /// <summary>
+        /// The device object is now paired.
+        /// </summary>
+        Paired = 0,
+
+        /// <summary>
+        /// The device object is not in a state where it can be paired.
+        /// </summary>
+        NotReadyToPair = 1,
+
+        /// <summary>
+        /// The device object is not currently paired.
+        /// </summary>
+        NotPaired = 2,
+
+        /// <summary>
+        /// The device object has already been paired.
+        /// </summary>
+        AlreadyPaired = 3,
+
+        /// <summary>
+        /// The device object rejected the connection.
+        /// </summary>
+        ConnectionRejected = 4,
+
+        /// <summary>
+        /// The device object indicated it cannot accept any more incoming connections.
+        /// </summary>
+        TooManyConnections = 5,
+
+        /// <summary>
+        ///  The device object indicated there was a hardware failure.
+        /// </summary>
+        HardwareFailure = 6,
+
+        /// <summary>
+        /// The authentication process timed out before it could complete.
+        /// </summary>
+        AuthenticationTimeout = 7,
+
+        /// <summary>
+        /// The authentication protocol is not supported, so the device is not paired.
+        /// </summary>
+        AuthenticationNotAllowed = 8,
+
+        /// <summary>
+        /// Authentication failed, so the device is not paired. Either the device object
+        /// or the application rejected the authentication.
+        /// </summary>
+        AuthenticationFailure = 9,
+
+        /// <summary>
+        /// here are no network profiles for this device object to use.
+        /// </summary>
+        NoSupportedProfiles = 10,
+
+        /// <summary>
+        /// The minimum level of protection is not supported by the device object or the
+        /// application.
+        /// </summary>
+        ProtectionLevelCouldNotBeMet = 11,
+
+        /// <summary>
+        /// Your application does not have the appropriate permissions level to pair the
+        /// device object.
+        /// </summary>
+        AccessDenied = 12,
+
+        /// <summary>
+        /// The ceremony data was incorrect.
+        /// </summary>
+        InvalidCeremonyData = 13,
+
+        /// <summary>
+        /// The pairing action was cancelled before completion.
+        /// </summary>
+        PairingCanceled = 14,
+
+        /// <summary>
+        ///  The device object is already attempting to pair or unpair.
+        /// </summary>
+        OperationAlreadyInProgress = 15,
+
+        /// <summary>
+        ///  Either the event handler wasn't registered or a required DevicePairingKinds was
+        ///  not supported.
+        /// </summary>
+        RequiredHandlerNotRegistered = 16,
+
+        /// <summary>
+        ///  The application handler rejected the pairing.
+        /// </summary>
+        RejectedByHandler = 17,
+
+        /// <summary>
+        ///  The remove device already has an association.
+        /// </summary>
+        RemoteDeviceHasAssociation = 18,
+
+        /// <summary>
+        ///  An unknown failure occurred.
+        /// </summary>
+        Failed = 19
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResult.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResult.cs
@@ -1,0 +1,26 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Contains information about the result of attempting to unpair a device.
+    /// </summary>
+    public class DeviceUnpairingResult
+    {
+        private readonly DeviceUnpairingResultStatus _status;
+
+        internal DeviceUnpairingResult(DeviceUnpairingResultStatus status)
+        {
+            _status = status;
+        }
+
+
+        /// <summary>
+        /// Gets the paired status of the device after the pairing action completed.
+        /// </summary>
+        public DeviceUnpairingResultStatus Status => _status;
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResultStatus.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResultStatus.cs
@@ -1,0 +1,38 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// The result of the unpairing action.
+    /// </summary>
+    public enum DeviceUnpairingResultStatus
+    {
+        /// <summary>
+        /// The device object is successfully unpaired.
+        /// </summary>
+        Unpaired = 0,
+
+        /// <summary>
+        /// The device object is successfully unpaired.
+        /// </summary>
+        AlreadyUnpaired = 1,
+
+        /// <summary>
+        /// The device object is successfully unpaired.
+        /// </summary>
+        OperationAlreadyInProgress = 2,
+
+        /// <summary>
+        /// The caller does not have sufficient permissions to unpair the device.
+        /// </summary>
+        AccessDenied = 3,
+
+        /// <summary>
+        /// An unknown failure occurred.
+        /// </summary>
+        Failed = 4
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResultStatus.cs
+++ b/nanoFramework.Device.Bluetooth/Security/DeviceUnpairingResultStatus.cs
@@ -16,12 +16,12 @@ namespace nanoFramework.Device.Bluetooth
         Unpaired = 0,
 
         /// <summary>
-        /// The device object is successfully unpaired.
+        /// The device object is already unpaired.
         /// </summary>
         AlreadyUnpaired = 1,
 
         /// <summary>
-        /// The device object is successfully unpaired.
+        /// Upairing operation already in progress.
         /// </summary>
         OperationAlreadyInProgress = 2,
 

--- a/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
+++ b/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
@@ -6,7 +6,7 @@
 namespace nanoFramework.Device.Bluetooth
 {
     /// <summary>
-    /// Object to hold password credentials
+    /// Class to hold password credentials.
     /// </summary>
     public class PasswordCredential
     {
@@ -14,10 +14,10 @@ namespace nanoFramework.Device.Bluetooth
         private string _password;
 
         /// <summary>
-        /// Constructs a PasswordCredential
+        /// Constructs a Password Credential.
         /// </summary>
-        /// <param name="userName">User name in credential</param>
-        /// <param name="password">Password for user name</param>
+        /// <param name="userName">User name in credential.</param>
+        /// <param name="password">Password for user name.</param>
         public PasswordCredential(string userName, string password)
         {
             _username = userName;
@@ -25,13 +25,13 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
-        /// Returns password from Credential
+        /// Gets password from Credential.
         /// </summary>
-        public string Password { get { return _password; } }
+        public string Password { get => _password; }
 
         /// <summary>
-        /// Returns User name from Credential
+        /// Gets User name from Credential.
         /// </summary>
-        public string UserName { get { return _username; } }
+        public string UserName { get => _username; }
     }
 }

--- a/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
+++ b/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
@@ -10,8 +10,8 @@ namespace nanoFramework.Device.Bluetooth
     /// </summary>
     public class PasswordCredential
     {
-        private string _username;
-        private string _password;
+        private readonly string _username;
+        private readonly string _password;
 
         /// <summary>
         /// Constructs a Password Credential.

--- a/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
+++ b/nanoFramework.Device.Bluetooth/Security/PasswordCredential.cs
@@ -1,0 +1,37 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth
+{
+    /// <summary>
+    /// Object to hold password credentials
+    /// </summary>
+    public class PasswordCredential
+    {
+        private string _username;
+        private string _password;
+
+        /// <summary>
+        /// Constructs a PasswordCredential
+        /// </summary>
+        /// <param name="userName">User name in credential</param>
+        /// <param name="password">Password for user name</param>
+        public PasswordCredential(string userName, string password)
+        {
+            _username = userName;
+            _password = password;
+        }
+
+        /// <summary>
+        /// Returns password from Credential
+        /// </summary>
+        public string Password { get { return _password; } }
+
+        /// <summary>
+        /// Returns User name from Credential
+        /// </summary>
+        public string UserName { get { return _username; } }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
+++ b/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
@@ -38,6 +38,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="BluetoothAddress.cs" />
     <Compile Include="BluetoothAddressType.cs" />
     <Compile Include="BluetoothConnectionStatus.cs" />
     <Compile Include="BluetoothDeviceId.cs" />
@@ -57,8 +58,11 @@
     <Compile Include="BluetoothLEDevice.cs" />
     <Compile Include="BluetoothLEManufacturerData.cs" />
     <Compile Include="BluetoothLEScanningMode.cs" />
+    <Compile Include="BluetoothLEServer.cs" />
     <Compile Include="BluetoothNanoDevice.cs" />
     <Compile Include="BluetoothSignalStrengthFilter.cs" />
+    <Compile Include="GenericAttributeProfile\GattSessionStatusChangedEventArgs.cs" />
+    <Compile Include="Security\DeviceBonding.cs" />
     <Compile Include="GenericAttributeProfile\GattCharacteristic.cs" />
     <Compile Include="GenericAttributeProfile\GattCharacteristicProperties.cs" />
     <Compile Include="GenericAttributeProfile\GattCharacteristicResult.cs" />
@@ -100,6 +104,17 @@
     <Compile Include="GenericAttributeProfile\GattDescriptorResult.cs" />
     <Compile Include="GenericAttributeProfile\GattWriteResult.cs" />
     <Compile Include="GenericAttributeProfile\IGattAttribute.cs" />
+    <Compile Include="Security\DevicePairingEventArgs.cs" />
+    <Compile Include="Security\DevicePairingIOCapabilities.cs" />
+    <Compile Include="Security\DevicePairingKinds .cs" />
+    <Compile Include="Security\DevicePairingProtectionLevel.cs" />
+    <Compile Include="Security\DevicePairingRequestedEventArgs.cs" />
+    <Compile Include="Security\DevicePairingResult.cs" />
+    <Compile Include="Security\DevicePairingResultStatus.cs" />
+    <Compile Include="Security\DeviceUnpairingResult.cs" />
+    <Compile Include="Security\DeviceUnpairingResultStatus.cs" />
+    <Compile Include="Security\DevicePairing.cs" />
+    <Compile Include="Security\PasswordCredential.cs" />
     <Compile Include="SPP\IBluetoothSpp.cs" />
     <Compile Include="SPP\NordicSpp.cs" />
     <Compile Include="SPP\SppReceiveEventArgs.cs" />


### PR DESCRIPTION
## Description
Changes to support pairing with security and authentication.

- Adds Various classes to support pairing from a Server or client application.
- Added a new singleton BluetoothLEServer class as a base class for all Server operations.  
- Added extra events to support pairing and client connections to servers.
- AddService removed from GattServiceProvider to be more consistent with Desktop version and due to new BluetoothLEServer class.
 

GattServiceProvider.Addservice is a breaking change.  Samples have been updated to just use a separate call to GattServiceProvider.

Still some tiding up to be done but that can be done later.


## Motivation and Context
Next stage of Bluetooth implementation

- Resolves nanoFramework/Home#1205

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested using Bluetooth samples which were updated to support pairing.
Extra Central3 sample added for testing.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
