### PR TITLE
Purge scan results

### DIFF
--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
@@ -31,5 +31,12 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
         ///// a received Bluetooth LE advertisement.
         ///// </summary>
         //public IList<BluetoothLEAdvertisementBytePattern> BytePatterns { get; }
+
+
+        internal bool Filter(BluetoothLEAdvertisementReceivedEventArgs args)
+        {
+            return true;
+        }
+
     }
 }

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
@@ -32,7 +32,6 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
         ///// </summary>
         //public IList<BluetoothLEAdvertisementBytePattern> BytePatterns { get; }
 
-
         internal bool Filter(BluetoothLEAdvertisementReceivedEventArgs args)
         {
             return true;

--- a/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
@@ -66,7 +66,6 @@ namespace nanoFramework.Device.Bluetooth
 
             NativeStartAdvertisementWatcher((int)_scanningMode);
             BluetoothLEServer._bluetoothEventManager.Watcher = this;
-
         }
 
         /// <summary>

--- a/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
@@ -19,12 +19,12 @@ namespace nanoFramework.Device.Bluetooth
         private short _outOfRangeThresholdInDBm;
         private TimeSpan _outOfRangeTimeout;
 
-        Timer _scanCheck;
-        Hashtable _scanResults = new();
-        Object _scanResultsLock = new Object();
+        private Timer _scanCheck;
+        private Hashtable _scanResults = new();
+        private Object _scanResultsLock = new Object();
 
-        const int DefaultDBM = -127;
-        const int DefaultOorTimeout = 60;
+        private const int DefaultDBM = -127;
+        private const int DefaultOorTimeout = 60;
 
         private class ScanItem
         {

--- a/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
@@ -2,7 +2,10 @@
 // Copyright (c) .NET Foundation and Contributors
 // See LICENSE file in the project root for full license information.
 //
+using nanoFramework.Device.Bluetooth.Advertisement;
 using System;
+using System.Collections;
+using System.Threading;
 
 namespace nanoFramework.Device.Bluetooth
 {
@@ -16,38 +19,187 @@ namespace nanoFramework.Device.Bluetooth
         private short _outOfRangeThresholdInDBm;
         private TimeSpan _outOfRangeTimeout;
 
+        Timer _scanCheck;
+        Hashtable _scanResults = new();
+        Object _scanResultsLock = new Object();
+
+        const int DEFAULT_DBM = -127;
+        const int DEFAULT_OOR_TIMEOUT = 60;
+
+        private class ScanItem
+        {
+            public short rssi;  // RSSI of last scan
+            public bool inRange; // True if device was in range.
+            public DateTime outRangeTime;  // Time device went out of range
+            public bool active;     // Scan item active, used for purging entries
+        }
+
         /// <summary>
         /// Create a new BluetoothSignalStrengthFilter object.
         /// </summary>
         public BluetoothSignalStrengthFilter()
         {
-            InRangeThresholdInDBm = -128;
-            OutOfRangeThresholdInDBm = -128;
-            OutOfRangeTimeout = new TimeSpan(0, 0, 10); // seconds
+            InRangeThresholdInDBm = DEFAULT_DBM;
+            OutOfRangeThresholdInDBm = DEFAULT_DBM;
+            OutOfRangeTimeout = new TimeSpan(0, 0, DEFAULT_OOR_TIMEOUT); // seconds
+
+            _scanResults = new Hashtable();
+
+            // Remove inactive entries from scan results every 1 minute 
+            TimeSpan time = new TimeSpan(0, 1, 0);
+            _scanCheck = new Timer(scanCheckCallback, 0, time, time);
         }
 
         ///// <summary>
-        ///// The interval at which received signal strength indicator (RSSI) events are sampled.
+        ///// The interval at which received signal strength indicator (RSSI) events are sampled.  (TODO)
         ///// </summary>
         //public TimeSpan? SamplingInterval { get; set; }
 
         /// <summary>
         /// The time out for a received signal strength indicator (RSSI) event to be considered
-        /// out of range.
+        /// out of range. Value between 1 and 60 seconds.
         /// </summary>
         public TimeSpan OutOfRangeTimeout { get => _outOfRangeTimeout; set => _outOfRangeTimeout = value; }
 
         /// <summary>
         /// The minimum received signal strength indicator (RSSI) value in dBm on which RSSI
-        /// events will be considered out of range.
+        /// events will be considered out of range. Value between +20 and -127. Default vale is -127.
         /// </summary>
         public short OutOfRangeThresholdInDBm { get => _outOfRangeThresholdInDBm; set => _outOfRangeThresholdInDBm = value; }
 
         /// <summary>
         /// The minimum received signal strength indicator (RSSI) value in dBm on which RSSI
         /// events will be propagated or considered in range if the previous events were
-        /// considered out of range.
+        /// considered out of range. Value between +20 and -127. Default vale is -127.
         /// </summary>
         public short InRangeThresholdInDBm { get => _inRangeThresholdInDBm; set => _inRangeThresholdInDBm = value; }
+
+        /// <summary>
+        /// Signal strength filter (RSSI).
+        /// </summary>
+        /// <param name="args">BluetoothLEAdvertisementReceivedEventArgs</param>
+        /// <returns>Returns False to ignore event</returns>
+        internal bool Filter(BluetoothLEAdvertisementReceivedEventArgs args)
+        {
+            // If default setting then just accept all events
+            if (InRangeThresholdInDBm == DEFAULT_DBM)
+            {
+                return true;
+            }
+
+            ScanItem scan = FindScanEntry(args.BluetoothAddress);
+            bool inRange = (args.RawSignalStrengthInDBm >= InRangeThresholdInDBm);
+            if (scan == null && inRange)
+            {
+                // New entry and in range then add it to list
+                scan = AddOrReplaceScanEntry(args.BluetoothAddress, args.RawSignalStrengthInDBm, inRange);
+            }
+
+            if (scan != null)
+            {
+                scan.active = true;  // flag entry as active so not purged
+
+                if (!inRange)
+                {
+                    if (args.RawSignalStrengthInDBm < OutOfRangeThresholdInDBm)
+                    {
+                        // Completely out of range, ignore
+                        DeleteScanEntry(args.BluetoothAddress);
+                        return false;
+                    }
+
+                    // In between in and out of range thresholds, check time out of range
+                    if (scan.inRange)
+                    {
+                        // If previously in range and now out
+                        // then set date time for time out of range
+                        AddOrReplaceScanEntry(args.BluetoothAddress, args.RawSignalStrengthInDBm, inRange);
+                    }
+                    else
+                    {
+                        // If previously moved out of range then check timer and still out of range.
+                        if ((scan.outRangeTime + OutOfRangeTimeout) < DateTime.UtcNow)
+                        {
+                            // Moved out of range for time out period
+                            // Remove scan
+                            DeleteScanEntry(args.BluetoothAddress);
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Called every 5 minutes to purge scan hash.
+        /// </summary>
+        /// <param name="state"></param>
+        private void scanCheckCallback(object state)
+        {
+            lock (_scanResultsLock)
+            {
+                ArrayList removeList = new ArrayList();
+
+                foreach (DictionaryEntry item in _scanResults)
+                {
+                    if (!((ScanItem)item.Value).active)
+                    {
+                        removeList.Add(item.Key);
+                    }
+                    else
+                    {
+                        ((ScanItem)item.Value).active = false;
+                    }
+                }
+
+                // Now delete expired items
+                foreach (ulong addressKey in removeList)
+                {
+                    DeleteScanEntry(addressKey);
+                }
+            }
+        }
+
+        private ScanItem FindScanEntry(UInt64 address)
+        {
+            if (_scanResults.Contains(address))
+            {
+                return (ScanItem)_scanResults[address];
+            }
+            return null;
+        }
+
+        private ScanItem AddOrReplaceScanEntry(UInt64 address, short Rssi, bool InRange)
+        {
+            ScanItem item = new()
+            {
+                rssi = Rssi,
+                inRange = InRange,
+                active = true
+            };
+
+            if (!InRange)
+            {
+                // It out of range now, save time for time out checking 
+                item.outRangeTime = DateTime.UtcNow;
+            }
+
+            DeleteScanEntry(address);
+
+            _scanResults.Add(address, item);
+
+            return item;
+        }
+
+        private void DeleteScanEntry(UInt64 address)
+        {
+            if (_scanResults.Contains(address))
+            {
+                _scanResults.Remove(address);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Change to BluetoothLEWatcher to regularly purge the scan results when no longer active.

## Motivation and Context
- Fixes nanoFramework/Home#1245

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Manually with modified Central1 sample

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
