### PR TITLE
Advertisement Publisher and filters

### DIFF
--- a/Tests/Client/Program.cs
+++ b/Tests/Client/Program.cs
@@ -156,17 +156,9 @@ namespace TestClient
                     EnvService.UpdateValue(iTempOutMin, t3);
                     Thread.Sleep(5000);
                 }
-
             }
 
-
             Thread.Sleep(Timeout.Infinite);
-        }
-
-        // Receive test commands
-        private static void Test_CommandRX(TestService sender, string args)
-        {
-            
         }
     }
 }

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisement.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisement.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections;
+using System.Text;
 
 namespace nanoFramework.Device.Bluetooth.Advertisement
 {
@@ -15,35 +16,112 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
     {
         private BluetoothLEAdvertisementFlags _flags;
         private string _localName;
-        private Guid[] _serviceUuids;
-        private BluetoothLEAdvertisementDataSection[] _dataSections;
+        private ArrayList _serviceUuids;
+        private ArrayList _dataSections;
         private ArrayList _manufacturerData;
-
-        // Used to import the byte arrays from Native code
-        private byte[] _rawUuids;
-        private byte[] _rawManufacturerData;
+        private bool _isConnectable;
+        private bool _isDiscovable;
 
         /// <summary>
         /// Creates a new BluetoothLEAdvertisement object.
         /// </summary>
         public BluetoothLEAdvertisement()
         {
-            _serviceUuids = new Guid[0];
-            _manufacturerData = new ArrayList();
+            _serviceUuids = new();
+            _manufacturerData = new();
             _localName = "";
-            _dataSections = null;
+            _dataSections = new();
             _flags = BluetoothLEAdvertisementFlags.ClassicNotSupported | BluetoothLEAdvertisementFlags.GeneralDiscoverableMode;
+            _isConnectable = false;
+            _isDiscovable = true;
+        }
+
+        #region Properties
+        /// <summary>
+        /// Gets the arrayList of raw _advertData sections.
+        /// </summary>
+        public ArrayList DataSections
+        {
+            get
+            {
+                MergeManufacturerArray();
+                return _dataSections;
+            }
         }
 
         /// <summary>
-        /// Return an ArrayList of advertisement data sections that matches a given advertisement
-        /// section type in a BluetoothLEAdvertisement.
+        /// The local name contained within the advertisement. This property can be either
+        /// the shortened or complete local name defined by the Bluetooth LE specifications.
         /// </summary>
+        public string LocalName
+        {
+            get => _localName;
+            set
+            {
+                _localName = value;
+
+                if (_localName == null || _localName.Length == 0)
+                {
+                    RemoveSectionsOfType(BluetoothLEAdvertisementDataSectionType.CompleteLocalName);
+                }
+                else
+                {
+                    // Update data section.
+                    DataWriter dw = new DataWriter();
+                    dw.WriteString(_localName);
+                    AddOrUpdateDataSection(BluetoothLEAdvertisementDataSectionType.CompleteLocalName, dw.DetachBuffer());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Bluetooth LE advertisement flags.
+        /// Defaults to ClassicNotSupported and GeneralDiscoverableMode.
+        /// </summary>
+        public BluetoothLEAdvertisementFlags Flags
+        {
+            get => _flags;
+            set
+            {
+                _flags = value;
+
+                // Update data section with new value.
+                AddOrUpdateDataSection(BluetoothLEAdvertisementDataSectionType.Flags, new Buffer(new byte[] { (byte)_flags }));
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of manufacturer-specific sections in a BluetoothLEAdvertisement.
+        /// </summary>
+        public ArrayList ManufacturerData { get => _manufacturerData; }
+
+        /// <summary>
+        /// The array of service UUIDs in 128-bit GUID format. This property aggregates all 
+        /// the 16-bit, 32-bit and 128-bit service UUIDs into a single array.
+        /// </summary>
+        public Guid[] ServiceUuids { get => (Guid[])_serviceUuids.ToArray(typeof(Guid)); }
+
+        /// <summary>
+        /// Internal property to get and set isConnectable property from service provider.
+        /// </summary>
+        internal bool IsConnectable { get => _isConnectable; set => _isConnectable = value; }
+
+        /// <summary>
+        /// Internal property to get and set IsDiscovable property from service provider.
+        /// </summary>
+        internal bool IsDiscovable { get => _isDiscovable; set => _isDiscovable = value; }
+
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Returns an ArrayList of all the BluetoothLEAdvertisementDataSection matching the given advertisement
+        /// type. This method returns an empty list if no such sections are found in the
+        /// payload.        /// </summary>
         /// <param name="type">The advertisement section type</param>
         /// <returns>
-        /// An ArrayList of all the BluetoothLEAdvertisementDataSection matching the given advertisement
-        /// type. This method returns an empty list if no such sections are found in the
-        /// payload.
+        /// BluetoothLEAdvertisementDataSection ArrayList of matching advertisement types.
+        /// This method returns an empty list if no such sections are found in the payload.
         /// </returns>
         public ArrayList GetSectionsByType(byte type)
         {
@@ -62,78 +140,14 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
         }
 
         /// <summary>
-        /// The local name contained within the advertisement. This property can be either
-        /// the shortened or complete local name defined by the Bluetooth LE specifications.
-        /// </summary>
-        public string LocalName { get => _localName; set => _localName = value.Trim(); }
-
-        /// <summary>
-        /// Bluetooth LE advertisement flags.
-        /// </summary>
-        public BluetoothLEAdvertisementFlags Flags { get => _flags; set => _flags = value; }
-
-        /// <summary>
-        /// Gets the arrayList of raw data sections.
-        /// </summary>
-        public ArrayList DataSections
-        {
-            get
-            {
-                ArrayList retList = new();
-                foreach (BluetoothLEAdvertisementDataSection s in _dataSections)
-                {
-                    retList.Add(s);
-                }
-                return retList;
-            }
-        }
-
-        /// <summary>
-        /// Process the RawManufacturerData bytes into array when available
-        /// </summary>
-        private void ProcessRawManufacturerData()
-        {
-            if (_rawManufacturerData != null && _rawManufacturerData.Length > 0)
-            {
-                _manufacturerData.Clear();
-
-                // first 2 bytes are company id
-                ushort CompanyID = (ushort)(_rawManufacturerData[0] + (_rawManufacturerData[1] << 8));
-
-                // Rest are the Manufacturers Data
-                byte[] mandata = new byte[_rawManufacturerData.Length - 2];
-                Array.Copy(_rawManufacturerData, 2, mandata, 0, _rawManufacturerData.Length - 2);
-
-                Buffer data = new(mandata);
-                _manufacturerData.Add(new BluetoothLEManufacturerData(CompanyID, data));
-                _rawManufacturerData = null;
-            }
-        }
-
-        /// <summary>
-        /// Gets the list of manufacturer-specific data sections in a BluetoothLEAdvertisement.
-        /// </summary>
-        public ArrayList ManufacturerData
-        {
-            get
-            {
-                ProcessRawManufacturerData();
-                return _manufacturerData;
-            }
-        }
-
-        /// <summary>
-        /// Return a list of all manufacturer data sections in the BluetoothLEAdvertisement
+        /// Return a list of all manufacturer Data sections in the BluetoothLEAdvertisement
         /// payload matching the specified company id.
         /// </summary>
         /// <param name="companyId">The company identifier code defined by the Bluetooth Special Interest Group (SIG).</param>
-        /// <returns>ArrayList of BluetoothLEManufacturerData by companyId</returns>
+        /// <returns>ArrayList of BluetoothLEManufacturerData by companyId.</returns>
         public ArrayList GetManufacturerDataByCompanyId(ushort companyId)
         {
             ArrayList subset = new();
-
-            // Process if not already done
-            ProcessRawManufacturerData();
 
             foreach (BluetoothLEManufacturerData obj in _manufacturerData)
             {
@@ -146,31 +160,253 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
             return subset;
         }
 
-        /// <summary>
-        /// The list of service UUIDs in 128-bit GUID format. This property 
-        /// the 16-bit, 32-bit and 128-bit service UUIDs into a single list.
-        /// </summary>
-        public Guid[] ServiceUuids
-        {
-            get
-            {
-                if (_rawUuids != null && _rawUuids.Length > 0)
-                {
-                    byte[] uuid = new byte[16];
+        #endregion
 
-                    // First time Parse Import array into guid array
-                    // linear byte[] with records of 16 bytes per UUID
-                    int numberUUIDS = _rawUuids.Length / 16;
-                    _serviceUuids = new Guid[numberUUIDS];
-                    for (int n = 0, i = 0; n < numberUUIDS; i += 16, n++)
-                    {
-                        Array.Copy(_rawUuids, i, uuid, 0, 16);
-                        _serviceUuids[n] = new Guid(uuid);
-                    }
-                    _rawUuids = null;
+        /// <summary>
+        /// Add or Update section in _dataSections ArrayList.
+        /// </summary>
+        /// <param name="type">Section type.</param>
+        /// <param name="data">Buffer with data.</param>
+        internal void AddOrUpdateDataSection(BluetoothLEAdvertisementDataSectionType type, Buffer data)
+        {
+            BluetoothLEAdvertisementDataSection bds = new BluetoothLEAdvertisementDataSection((byte)type, data);
+
+            for (int index = 0; index < _dataSections.Count; index++)
+            {
+                BluetoothLEAdvertisementDataSection ds = (BluetoothLEAdvertisementDataSection)_dataSections[index];
+                if ((BluetoothLEAdvertisementDataSectionType)ds.DataType == type)
+                {
+                    // Replace section
+                    _dataSections[index] = bds;
+                    return;
                 }
-                return _serviceUuids;
             }
+
+            // Add new service
+            _dataSections.Add(bds);
+        }
+
+        #region Parse raw incoming advert byte array data
+
+        /// <summary>
+        /// Parse the byte array received from native code into _advertData sections and relevant properties.
+        /// </summary>
+        /// <param name="bytes"></param>
+        internal void ParseBytesToSectionData(byte[] bytes)
+        {
+            int byteIndex = 0;
+
+            // Clear arrays
+            _serviceUuids.Clear();
+            _manufacturerData.Clear();
+
+            // Each section is composed of 1 byte dataLength following _advertData, 1 byte type, Data bytes
+            // TODO check dataLength 
+            while (byteIndex < bytes.Length)
+            {
+                int dataLength = bytes[byteIndex++] - 1;
+                byte dataType = bytes[byteIndex++];
+
+                // Extract _advertData section from byte array
+                byte[] dataBytes = new byte[dataLength];
+                Array.Copy(bytes, byteIndex, dataBytes, 0, dataLength);
+                Buffer buffer = new Buffer(dataBytes);
+
+                byteIndex += dataLength;
+
+                BluetoothLEAdvertisementDataSection dataSection = new BluetoothLEAdvertisementDataSection(dataType, buffer);
+                _dataSections.Add(dataSection);
+
+                LoadDataSectionToProperty(dataSection);
+            }
+        }
+
+        private void LoadDataSectionToProperty(BluetoothLEAdvertisementDataSection ds)
+        {
+            switch ((BluetoothLEAdvertisementDataSectionType)ds.DataType)
+            {
+                case BluetoothLEAdvertisementDataSectionType.Flags:
+                    _flags = (BluetoothLEAdvertisementFlags)ds.Data.Data[0];
+                    break;
+
+                // Local name
+                case BluetoothLEAdvertisementDataSectionType.ShortenedLocalName:
+                case BluetoothLEAdvertisementDataSectionType.CompleteLocalName:
+                    _localName = Encoding.UTF8.GetString(ds.Data.Data, 0, ds.Data.Data.Length);
+                    break;
+
+                case BluetoothLEAdvertisementDataSectionType.ManufacturerSpecificData:
+                    ParseManufacturerData(ds.Data.Data);
+                    break;
+
+                // Service UUID
+                case BluetoothLEAdvertisementDataSectionType.CompleteList16uuid:
+                case BluetoothLEAdvertisementDataSectionType.IncompleteList16uuid:
+                case BluetoothLEAdvertisementDataSectionType.CompleteList32uuid:
+                case BluetoothLEAdvertisementDataSectionType.IncompleteList32uuid:
+                case BluetoothLEAdvertisementDataSectionType.CompleteList128uuid:
+                case BluetoothLEAdvertisementDataSectionType.IncompleteList128uuid:
+                    ParseUuidList(ds.Data.Data);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Load properties from DataSection array
+        /// </summary>
+        private void loadPropertiesFromDataSections()
+        {
+            foreach (BluetoothLEAdvertisementDataSection ds in _dataSections)
+            {
+                LoadDataSectionToProperty(ds);
+            }
+        }
+
+        /// <summary>
+        /// Parse raw manufacturer data into _manufacturerData arrayList
+        /// </summary>
+        /// <param name="rawManufacturerData"></param>
+        private void ParseManufacturerData(byte[] rawManufacturerData)
+        {
+            // first 2 bytes are company id
+            ushort CompanyID = (ushort)(rawManufacturerData[0] + (rawManufacturerData[1] << 8));
+
+            // Rest are the Manufacturers Data
+            byte[] mandata = new byte[rawManufacturerData.Length - 2];
+            Array.Copy(rawManufacturerData, 2, mandata, 0, rawManufacturerData.Length - 2);
+
+            Buffer data = new(mandata);
+            _manufacturerData.Add(new BluetoothLEManufacturerData(CompanyID, data));
+        }
+
+        /// <summary>
+        /// Parse byte array of UUID into service UUIDS.
+        /// </summary>
+        /// <param name="rawUuidData"></param>
+        private void ParseUuidList(byte[] rawUuidData)
+        {
+            int numberUUIDS = rawUuidData.Length / 16;
+
+            DataReader uRdr = DataReader.FromBuffer(new Buffer(rawUuidData));
+
+            for (int n = 0, i = 0; n < numberUUIDS; i += 16, n++)
+            {
+                _serviceUuids.Add(uRdr.ReadUuid());
+            }
+        }
+
+        #endregion
+
+        internal void RemoveSectionsOfType(BluetoothLEAdvertisementDataSectionType sectionType)
+        {
+            for (int i = _dataSections.Count - 1; i >= 0; i--)
+            {
+                BluetoothLEAdvertisementDataSection ds = (BluetoothLEAdvertisementDataSection)_dataSections[i];
+                if (ds.DataType == (byte)sectionType)
+                {
+                    _dataSections.RemoveAt(i);
+                }
+            }
+        }
+
+        private void MergeManufacturerArray()
+        {
+            // First remove all manufacturer data from data sections list
+            RemoveSectionsOfType(BluetoothLEAdvertisementDataSectionType.ManufacturerSpecificData);
+
+            foreach(BluetoothLEManufacturerData md in _manufacturerData)
+            {
+                DataWriter dw = new DataWriter();
+                dw.WriteUInt16(md.CompanyId);
+                for (int i = 0; i < md.Data.Length; i++)
+                {
+                    dw.WriteByte(md.Data.Data[i]);
+                }
+
+                BluetoothLEAdvertisementDataSection bds = new BluetoothLEAdvertisementDataSection((byte)BluetoothLEAdvertisementDataSectionType.ManufacturerSpecificData, dw.DetachBuffer());
+
+                _dataSections.Add(bds);
+            }
+        }
+
+
+        /// <summary>
+        /// Merge the scan response advertisement into original advertisement so all data sections are together.
+        /// </summary>
+        /// <param name="mergeAdvert"></param>
+        internal void MergeAdvertisement(BluetoothLEAdvertisement mergeAdvert)
+        {
+            foreach (BluetoothLEAdvertisementDataSection ds in mergeAdvert.DataSections)
+            {
+                _dataSections.Add(ds);
+            }
+            loadPropertiesFromDataSections();
+        }
+
+        /// <summary>
+        /// Create a 31 byte legacy advertisement bytes.
+        /// Any sections that don't fix in advertisement then add to scan response.
+        /// </summary>
+        /// <returns>True if data didn't fit advert or scan response.</returns>
+        internal bool CreateLegacyAdvertisements(out byte[] advertData, out byte[] scanResponse)
+        {
+            int advertIndex = 0;
+            int srIndex = 0;
+            bool advertNotFit = false;
+
+            ArrayList noFitList = new ArrayList();
+
+            const int MAX_ADVERT_SIZE = 31;
+
+            // Initialize buffer to max dataLength
+            advertData = new byte[MAX_ADVERT_SIZE];
+            scanResponse = new byte[MAX_ADVERT_SIZE];
+
+            MergeManufacturerArray();
+
+            // Add data sections to _advertData
+            foreach (BluetoothLEAdvertisementDataSection ds in _dataSections)
+            {
+                int len = ds.AdvertisentLength();
+                if (advertIndex + len <= MAX_ADVERT_SIZE)
+                {
+                    Array.Copy(ds.ToAdvertisentBytes(), 0, advertData, advertIndex, len);
+                    advertIndex += len;
+                }
+                else
+                {
+                    // Add to list of items that don't fit in primary advert
+                    noFitList.Add(ds);
+                }
+            }
+
+            // Add data sections that didn't fit in advert to scan response
+            foreach (BluetoothLEAdvertisementDataSection ds in noFitList)
+            {
+                int len = ds.AdvertisentLength();
+                if (srIndex + len <= MAX_ADVERT_SIZE)
+                {
+                    Array.Copy(ds.ToAdvertisentBytes(), 0, scanResponse, srIndex, len);
+                    srIndex += len;
+                }
+                else
+                {
+                    // ignore this section and set return flag
+                    advertNotFit = true;
+                }
+            }
+
+            // adjust arrays to correct exact size of data
+            advertData = AdjustByteArraySize(advertData, advertIndex);
+            scanResponse = AdjustByteArraySize(scanResponse, srIndex);
+
+            return advertNotFit;
+        }
+
+        private byte[] AdjustByteArraySize(byte[] array, int len)
+        {
+            SpanByte sb = new SpanByte(array).Slice(0, len);
+            return sb.ToArray();
         }
     }
 }

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementBytePattern.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementBytePattern.cs
@@ -1,0 +1,56 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace nanoFramework.Device.Bluetooth.Advertisement
+{
+    /// <summary>
+    /// A Bluetooth LE advertisement byte pattern for filters to match.
+    /// </summary>
+    public class BluetoothLEAdvertisementBytePattern
+    {
+        private byte _dataType;
+        private Buffer _data;
+        private short _offset;
+
+        /// <summary>
+        /// Create a new BluetoothLEAdvertisementBytePattern object.
+        /// </summary>
+        public BluetoothLEAdvertisementBytePattern() : this(0, 0, null)
+        {
+        }
+
+        /// <summary>
+        /// Create a new BluetoothLEAdvertisementBytePattern object with an advertisement data type to match, the
+        /// advertisement data byte pattern to match, and the offset of the byte pattern from the beginning of the advertisement
+        /// data section.
+        /// </summary>
+        /// <param name="dataType">The Bluetooth LE advertisement data type to match.</param>
+        /// <param name="offset">The offset of byte pattern from beginning of advertisement data section.</param>
+        /// <param name="data">The Bluetooth LE advertisement data byte pattern to match.</param>
+        public BluetoothLEAdvertisementBytePattern(byte dataType, short offset, Buffer data)
+        {
+            _dataType = dataType;
+            _offset = offset;
+            _data = data;
+        }
+
+        /// <summary>
+        /// The Bluetooth LE advertisement data type defined by the Bluetooth Special Interest Group (SIG) to match.
+        /// </summary>
+        public byte DataType { get => _dataType; set => _dataType = value; }
+
+        /// <summary>
+        /// The Bluetooth LE advertisement data byte pattern to match.
+        /// </summary>
+        public Buffer Data { get => _data; set => _data = value; }
+
+        /// <summary>
+        /// The offset of byte pattern from beginning of advertisement data section.
+        /// </summary>
+        public short Offset { get => _offset; set => _offset = value; }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementDataSection.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementDataSection.cs
@@ -3,6 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
+
 namespace nanoFramework.Device.Bluetooth.Advertisement
 {
     /// <summary>
@@ -43,5 +45,30 @@ namespace nanoFramework.Device.Bluetooth.Advertisement
         /// The Bluetooth LE advertisement data payload.
         /// </summary>
         public Buffer Data { get => _buffer; set => _buffer = value; }
+
+        /// <summary>
+        /// Returns a byte array formatted with data section data in format for adverts.
+        /// 1 byte length, 1 byte type, bytes data
+        /// </summary>
+        /// <returns>Byte array for advert section.</returns>
+        internal byte[] ToAdvertisentBytes()
+        {
+            byte[] data = new byte[_buffer.Length + 2];
+
+            data[0] = (byte)(_buffer.Length + 1);
+            data[1] = _dataType;
+            Array.Copy(_buffer.Data, 0, data, 2, (int)_buffer.Length);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Returns length of advertisement bytes.
+        /// </summary>
+        /// <returns></returns>
+        internal int AdvertisentLength() 
+        {
+            return (int)_buffer.Length + 2;
+        }
     }
 }

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementDataSectionType.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementDataSectionType.cs
@@ -1,0 +1,123 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth.Advertisement
+{
+    /// <summary>
+    /// Data type values used in BluetoothLEAdvertisementDataSection.
+    /// </summary>
+    public enum BluetoothLEAdvertisementDataSectionType
+    {
+        /// <summary>
+        /// Section data type for the Bluetooth LE advertising interval.
+        /// </summary>
+        AdvertisingInterval = 0x1A,
+
+        /// <summary>
+        /// Section data type for the Bluetooth LE advertising appearance.
+        /// </summary>
+        Appearance = 0x19,
+
+        /// <summary>
+        /// Section data type for the Bluetooth LE complete local name.
+        /// </summary>
+        CompleteLocalName = 0x09,
+
+        /// <summary>
+        /// Section data type for the complete list of 128-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        CompleteList128uuid = 0x07,
+
+        /// <summary>
+        /// Section data type for the complete list of 16-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        CompleteList16uuid = 0x03,
+
+        /// <summary>
+        /// Section data type for the complete list of 32-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        CompleteList32uuid = 0x05,
+
+        /// <summary>
+        /// Section data type for a set of flags for internal use.
+        /// </summary>
+        Flags = 0x01,
+
+        /// <summary>
+        /// Section data type for an incomplete list of 128-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        IncompleteList128uuid = 0x06,
+
+        /// <summary>
+        /// Section data type for an incomplete list of 16-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        IncompleteList16uuid = 0x02,
+
+        /// <summary>
+        /// Section data type for an incomplete list of 32-bit Bluetooth LE service UUIDs.
+        /// </summary>
+        IncompleteList32uuid = 0x04,
+
+        /// <summary>
+        /// Section data type for manufacturer-specific data for a Bluetooth LE advertisements.
+        /// </summary>
+        ManufacturerSpecificData = 0xFF,
+
+        /// <summary>
+        /// Section data type for the Peripheral connection interval range.
+        /// </summary>
+        PeripheralConnectionIntervalRange = 0x12,
+
+        /// <summary>
+        /// Section data type for a list of public Bluetooth LE target addresses.
+        /// </summary>
+        PublicTargetAddress = 0x17,
+
+        /// <summary>
+        /// Section data type for a list of random Bluetooth LE target addresses.
+        /// </summary>
+        RandomTargetAddress = 0x18,
+
+        /// <summary>
+        /// Section data type for service data for 128-bit Bluetooth LE UUIDs.
+        /// </summary>
+        ServiceData128bitUuid = 0x21,
+
+        /// <summary>
+        /// Section data type for service data for 16-bit Bluetooth LE UUIDs.
+        /// </summary>
+        ServiceData16bitUuid = 0x16,
+
+        /// <summary>
+        /// Section data type for service data for 32-bit Bluetooth LE UUIDs.
+        /// </summary>
+        ServiceData32bitUuid = 0x20,
+
+        /// <summary>
+        /// Section data type for a list of 128-bit Bluetooth LE service solicitation UUIDs.
+        /// </summary>
+        ServiceSolicitation128BitUuids = 0x15,
+
+        /// <summary>
+        /// Section data type for a list of 16-bit Bluetooth LE service solicitation UUIDs.
+        /// </summary>
+        ServiceSolicitation16BitUuids = 0x14,
+
+        /// <summary>
+        /// Section data type for a list of 32-bit Bluetooth LE service solicitation UUIDs.
+        /// </summary>
+        ServiceSolicitation32BitUuids = 0x1F,
+
+        /// <summary>
+        /// Section data type for a shortened local name.
+        /// </summary>
+        ShortenedLocalName = 0x08,
+
+        /// <summary>
+        /// Section data type for the Bluetooth LE transmit power level.
+        /// </summary>
+        TxPowerLevel = 0x0A
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementFilter.cs
@@ -3,39 +3,116 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections;
+
 namespace nanoFramework.Device.Bluetooth.Advertisement
 {
     /// <summary>
     /// Groups parameters used to configure payload-based filtering of received Bluetooth
     /// LE advertisements.
     /// </summary>
-    public class BluetoothLEAdvertisementFilter 
+    public class BluetoothLEAdvertisementFilter
     {
+        private BluetoothLEAdvertisement _advertisement;
+        private ArrayList _bytePatterns;
+
         /// <summary>
         /// Creates a new BluetoothLEAdvertisementFilter object.
         /// </summary>
         public BluetoothLEAdvertisementFilter()
         {
+            _advertisement = new BluetoothLEAdvertisement();
+            _bytePatterns = new ArrayList();
         }
 
-        // TODO
-        ///// <summary>
-        ///// A BluetoothLEAdvertisement object that can be applied as filters to received
-        ///// Bluetooth LE advertisements.
-        ///// </summary>
-        //public BluetoothLEAdvertisement Advertisement { get; set; }
+        /// <summary>
+        /// A BluetoothLEAdvertisement object that can be applied as filters to received
+        /// Bluetooth LE advertisements.
+        /// </summary>
+        public BluetoothLEAdvertisement Advertisement { get => _advertisement; set => _advertisement = value; }
 
-        // TODO
-        ///// <summary>
-        ///// Gets a vector of byte patterns with offsets to match advertisement sections in
-        ///// a received Bluetooth LE advertisement.
-        ///// </summary>
-        //public IList<BluetoothLEAdvertisementBytePattern> BytePatterns { get; }
+        /// <summary>
+        /// Gets a arrayList of byte patterns with offsets to match advertisement sections in
+        /// a received Bluetooth LE advertisement.
+        /// </summary>
+        public ArrayList BytePatterns { get => _bytePatterns; }
 
         internal bool Filter(BluetoothLEAdvertisementReceivedEventArgs args)
         {
+            // Check BluetoothLEAdvertisement filter
+            foreach (BluetoothLEAdvertisementDataSection ds in _advertisement.DataSections)
+            {
+                // find filter data section type in advertisement
+                ArrayList sections = args.Advertisement.GetSectionsByType(ds.DataType);
+                if (sections.Count == 0)
+                {
+                    return false;
+                }
+
+                // Check data section in advertisement is same value as whats in filer
+                BluetoothLEAdvertisementDataSection fds = (BluetoothLEAdvertisementDataSection)sections[0];
+                if (!CompareBufferWithOffset(ds.Data, fds.Data, 0))
+                {
+                    return false;
+                }
+            }
+
+            // Check BluetoothLEAdvertisementBytePattern filter
+            foreach (BluetoothLEAdvertisementBytePattern bp in _bytePatterns)
+            {
+                ArrayList sections = args.Advertisement.GetSectionsByType(bp.DataType);
+                if (sections.Count == 0)
+                {
+                    return false;
+                }
+
+                BluetoothLEAdvertisementDataSection fds = (BluetoothLEAdvertisementDataSection)sections[0];
+                if (!CompareBufferWithOffset(fds.Data, bp.Data, bp.Offset))
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
 
+        // Check byte pattern is in byte[] at offset.
+        private bool CompareByteArrayOffset(byte[] a, byte[] b, uint blen, short boffset)
+        {
+            // Check offset is in data
+            if (a.Length < (blen + boffset))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < blen; i++)
+            {
+                if (a[i] != b[i + boffset])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        private bool CompareBufferWithOffset(Buffer a, Buffer b, short boffset)
+        {
+            // Check offset is in data
+            if (a.Length < (b.Length + boffset))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < b.Length; i++)
+            {
+                if (a.Data[i + boffset] != b.Data[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisher.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisher.cs
@@ -1,0 +1,193 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections;
+using System.Runtime.CompilerServices;
+
+namespace nanoFramework.Device.Bluetooth.Advertisement
+{
+    /// <summary>
+    /// The BluetoothLEAdvertisementPublisher class allows the configuration and 
+    /// advertising of a Bluetooth LE advertisement packet.
+    /// </summary>
+    public class BluetoothLEAdvertisementPublisher
+    {
+        private readonly BluetoothLEAdvertisement _advertisement;
+        private BluetoothLEAdvertisementPublisherStatus _status;
+        private bool _useExtendedAdvertisement;
+        private bool _includeTransmitPowerLevel;
+        private bool _isAnonymous;
+        private short _preferredTransmitPowerLevelInDBm;
+        private bool _dataNotFitInAdvertisement = false;
+
+        private static short _advertisementInstance = 0;  // Extended only
+
+        /// <summary>
+        /// Delegate for notification that the status of the BluetoothLEAdvertisementPublisher has changed.
+        /// </summary>
+        /// <param name="sender">BluetoothLEAdvertisementPublisher class sending event.</param>
+        /// <param name="args">Event arguments.</param>
+        public delegate void BluetoothLEAdvertisementPublisherHandler(Object sender, BluetoothLEAdvertisementPublisherStatusChangedEventArgs args);
+
+        /// <summary>
+        /// Notification that the status of the BluetoothLEAdvertisementPublisher has changed.
+        /// </summary>
+        public event BluetoothLEAdvertisementPublisherHandler StatusChanged;
+
+        /// <summary>
+        /// Creates a new BluetoothLEAdvertisementPublisher object.
+        /// </summary>
+        public BluetoothLEAdvertisementPublisher(): this(new BluetoothLEAdvertisement())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new BluetoothLEAdvertisementPublisher object with the Bluetooth LE advertisement to publish.
+        /// </summary>
+        /// <param name="advertisement">The Bluetooth LE advertisement to publish.</param>
+        public BluetoothLEAdvertisementPublisher(BluetoothLEAdvertisement advertisement)
+        {
+            _advertisement = advertisement;
+            _status = BluetoothLEAdvertisementPublisherStatus.Created;
+            _useExtendedAdvertisement = false;
+            _includeTransmitPowerLevel = false;
+            _isAnonymous = false;
+        }
+
+        /// <summary>
+        /// Gets a copy of the Bluetooth LE advertisement to publish.
+        /// </summary>
+        public BluetoothLEAdvertisement Advertisement { get => _advertisement; }
+
+        /// <summary>
+        /// Specifies whether the transmit power level is included in the advertisement header. 
+        /// Defaults to False.
+        /// </summary>
+        public bool IncludeTransmitPowerLevel { get => _includeTransmitPowerLevel; set => _includeTransmitPowerLevel = value; }
+
+        /// <summary>
+        /// Specifies whether or not the device address is included in the advertisement header. 
+        /// By default, the address is included.
+        /// </summary>
+        public bool IsAnonymous { get => _isAnonymous; set => _isAnonymous = value; }
+
+        /// <summary>
+        /// If specified, requests that the radio use the indicated transmit power level for the advertisement. 
+        /// Defaults to 0.        
+        /// </summary>
+        public short PreferredTransmitPowerLevelInDBm { get => _preferredTransmitPowerLevelInDBm; set => _preferredTransmitPowerLevelInDBm = value; }
+
+        /// <summary>
+        /// Gets the current status of the BluetoothLEAdvertisementPublisher.
+        /// </summary>
+        public BluetoothLEAdvertisementPublisherStatus Status 
+        { 
+            get => _status; 
+            internal set 
+            {
+                if (_status == value)
+                    return;
+
+                _status = value;
+
+                StatusChanged?.Invoke(this, 
+                    new BluetoothLEAdvertisementPublisherStatusChangedEventArgs(_status, 0, _preferredTransmitPowerLevelInDBm));
+            }
+        }
+
+        /// <summary>
+        /// Specifies that the advertisement publisher should use the Extended Advertising format.
+        /// Defaults to False, use legacy advertisements. If Bluetooth 5.0 not available on target platform
+        /// then a PlatformNotSupportedException will be thrown.
+        /// </summary>
+        public bool UseExtendedAdvertisement
+        {
+            get => _useExtendedAdvertisement;
+            set
+            {
+                if (value && !NativeIsExtendedAdvertisingAvailable())
+                {
+                    throw new PlatformNotSupportedException();
+                }
+                _useExtendedAdvertisement = value;
+            }
+        }
+
+        /// <summary>
+        /// Flag for internal use by Gatt service provider.
+        /// Indicates that all data didn't fix in 31 byte advertisement or scan response.
+        /// </summary>
+        internal bool DataNotFitInAdvertisement { get => _dataNotFitInAdvertisement; }
+
+        /// <summary>
+        /// Start advertising a Bluetooth LE advertisement payload.
+        /// </summary>
+        public void Start()
+        {
+            byte[] advertData;
+            byte[] scanResponse;
+
+            // Check and switch to server mode
+            if (BluetoothNanoDevice.RunMode != BluetoothNanoDevice.Mode.Server)
+            {
+                BluetoothLEServer.Instance.Start();
+            }
+
+            // Make sure pairing attributes set
+            BluetoothLEServer.Instance.Pairing.SetPairAttributes();
+
+            Status = BluetoothLEAdvertisementPublisherStatus.Waiting;
+
+            if (_useExtendedAdvertisement)
+            {
+                //TODO extended advertisement currently not supported
+
+                _advertisementInstance++; // Increment instance value
+
+                //_advertisement.CreateExtendedAdvertisement(out advertData);
+                throw new NotSupportedException();
+
+                //if (NativeStartExtendedAdvertising(_advertisementInstance, advertData))
+                //{
+                //    Status = BluetoothLEAdvertisementPublisherStatus.Started;
+                //}
+            }
+            else
+            {
+                _dataNotFitInAdvertisement = _advertisement.CreateLegacyAdvertisements(out advertData, out scanResponse);
+                if (NativeStartLegacyAdvertising(advertData, scanResponse))
+                {
+                    Status = BluetoothLEAdvertisementPublisherStatus.Started;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stop the publisher and stop advertising a Bluetooth LE advertisement payload.
+        /// </summary>
+        public void Stop()
+        {
+            NativeStopAdvertising();
+            Status = BluetoothLEAdvertisementPublisherStatus.Stopped;
+        }
+
+        #region external calls to native implementations
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern bool NativeStartLegacyAdvertising(byte[] advertData, byte[] scanResponse);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern bool NativeStartExtendedAdvertising(short instance, byte[] advertData);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeStopAdvertising();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern bool NativeIsExtendedAdvertisingAvailable();
+
+        #endregion
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisherStatus.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisherStatus.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth.Advertisement
+{
+    /// <summary>
+    /// Represents the possible states of the BluetoothLEAdvertisementPublisher.
+    /// </summary>
+    public enum BluetoothLEAdvertisementPublisherStatus
+    {
+        /// <summary>
+        /// The initial status of the publisher.
+        /// </summary>
+        Created = 0,
+
+        /// <summary>
+        /// The publisher is waiting to get service time.
+        /// </summary>
+        Waiting = 1,
+
+        /// <summary>
+        /// The publisher is being serviced and has started advertising.
+        /// </summary>
+        Started = 2,
+
+        /// <summary>
+        /// The publisher was issued a stop command.
+        /// </summary>
+        Stopping = 3,
+
+        /// <summary>
+        /// The publisher was issued a stop command.
+        /// </summary>
+        Stopped = 4,
+
+        /// <summary>
+        /// The publisher is aborted due to an error.
+        /// </summary>
+        Aborted = 5
+    }
+}

--- a/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisherStatusChangedEventArgs.cs
+++ b/nanoFramework.Device.Bluetooth/Advertisement/BluetoothLEAdvertisementPublisherStatusChangedEventArgs.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Device.Bluetooth.Advertisement
+{
+    /// <summary>
+    /// Provides data for a StatusChanged event on a BluetoothLEAdvertisementPublisher.
+    /// </summary>
+    public class BluetoothLEAdvertisementPublisherStatusChangedEventArgs
+    {
+        private readonly BluetoothError _error;
+        private readonly BluetoothLEAdvertisementPublisherStatus _status;
+        private readonly short _selectedTransmitPowerLevelInDBm;
+
+        internal BluetoothLEAdvertisementPublisherStatusChangedEventArgs(BluetoothLEAdvertisementPublisherStatus status, BluetoothError error, short selectedTransmitPowerLevelInDBm)
+        {
+            _status = status;
+            _error = error;
+            _selectedTransmitPowerLevelInDBm = selectedTransmitPowerLevelInDBm;
+        }
+
+        /// <summary>
+        /// Gets the error status for a StatusChanged event on a BluetoothLEAdvertisementPublisher.
+        /// </summary>
+        public BluetoothError Error { get => _error; }
+
+        /// <summary>
+        /// Gets the new status of the BluetoothLEAdvertisementPublisher.
+        /// </summary>
+        public BluetoothLEAdvertisementPublisherStatus Status { get => _status; }
+
+        /// <summary>
+        /// The current transmit power selected. 
+        /// If the Extended Advertisement format is not supported by the adapter, this instead represents the adapter's default transmit power level.
+        /// </summary>
+        public short SelectedTransmitPowerLevelInDBm { get => _selectedTransmitPowerLevelInDBm; }
+    }
+}

--- a/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothEventListener.cs
@@ -329,7 +329,7 @@ namespace nanoFramework.Device.Bluetooth
                         switch (btEvent.type)
                         {
                             case BluetoothEventType.AdvertisementDiscovered:
-                                BluetoothLEAdvertisementReceivedEventArgs eventRxArgs = BluetoothLEAdvertisementReceivedEventArgs.CreateFromEvent(btEvent.id);
+                                BluetoothLEAdvertisementReceivedEventArgs eventRxArgs = BluetoothLEAdvertisementReceivedEventArgs.CreateFromEvent(_watcher, btEvent.id);
                                 eventRxArgs.Timestamp = DateTime.UtcNow;
                                 _watcher?.OnReceived(eventRxArgs);
                                 break;

--- a/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEAdvertisementWatcher.cs
@@ -110,18 +110,23 @@ namespace nanoFramework.Device.Bluetooth
         internal void OnReceived(BluetoothLEAdvertisementReceivedEventArgs args)
         {
             // Check filters
+            // Advertisement section Filter 
+            if (_advertisementFilter != null && !_advertisementFilter.Filter(args))
+            {
+                return;
+            }
+
             // Signal strength filter
             if (!_signalStrengthFilter.Filter(args))
             {
                 return;
             }
 
-            // Advertisement section Filter (TODO)
-            if (_advertisementFilter != null && !_advertisementFilter.Filter(args))
-            {
-                return;
-            }
+            FireEvent(args);
+        }
 
+        internal void FireEvent(BluetoothLEAdvertisementReceivedEventArgs args)
+        {
             Received?.Invoke(this, args);
         }
 

--- a/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothLEServer.cs
@@ -86,7 +86,7 @@ namespace nanoFramework.Device.Bluetooth
         public ushort Appearance { get => BluetoothNanoDevice.Appearance; set => BluetoothNanoDevice.Appearance = value; }
 
         /// <summary>
-        /// Get GattSession aasoicated with this server.
+        /// Get GattSession associated with this server.
         /// </summary>
         public GattSession Session { get => _session; }
 
@@ -169,7 +169,7 @@ namespace nanoFramework.Device.Bluetooth
         #endregion Security
 
         /// <summary>
-        /// Starts Bluetoth stack for server mode.
+        /// Starts Bluetooth stack for server mode.
         /// </summary>
         /// <exception cref="InvalidOperationException">If already running or in Client mode.</exception>
         public void Start()
@@ -201,10 +201,10 @@ namespace nanoFramework.Device.Bluetooth
             {
                 case BluetoothEventType.ClientConnected:
                 case BluetoothEventType.ClientDisconnected:
+                case BluetoothEventType.ClientSessionChanged:
                     _session.OnEvent(btEvent);
                     break;
 
-                case BluetoothEventType.ClientSessionChanged:
                 case BluetoothEventType.PassKeyActions:
                 case BluetoothEventType.PassKeyActionsNumericComparison:
                 case BluetoothEventType.AuthenticationComplete:

--- a/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothNanoDevice.cs
@@ -49,7 +49,7 @@ namespace nanoFramework.Device.Bluetooth
                 BluetoothNanoDevice.RunMode = expectedMode;
             }
         }
-
+ 
         /// <summary>
         /// Get/Set the current mode of the device.
         /// </summary>

--- a/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
+++ b/nanoFramework.Device.Bluetooth/BluetoothSignalStrengthFilter.cs
@@ -13,7 +13,7 @@ namespace nanoFramework.Device.Bluetooth
     /// Groups parameters used to configure received signal strength indicator (RSSI)-based
     /// filtering.
     /// </summary>
-    public class BluetoothSignalStrengthFilter 
+    public class BluetoothSignalStrengthFilter
     {
         private short _inRangeThresholdInDBm;
         private short _outOfRangeThresholdInDBm;
@@ -59,20 +59,54 @@ namespace nanoFramework.Device.Bluetooth
         /// The time out for a received signal strength indicator (RSSI) event to be considered
         /// out of range. Value between 1 and 60 seconds.
         /// </summary>
-        public TimeSpan OutOfRangeTimeout { get => _outOfRangeTimeout; set => _outOfRangeTimeout = value; }
+        public TimeSpan OutOfRangeTimeout
+        {
+            get => _outOfRangeTimeout;
+            set
+            {
+                if (value.TotalMilliseconds < 1000 || value.Milliseconds > 60000)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                _outOfRangeTimeout = value;
+            }
+
+        }
 
         /// <summary>
         /// The minimum received signal strength indicator (RSSI) value in dBm on which RSSI
         /// events will be considered out of range. Value between +20 and -127. Default vale is -127.
         /// </summary>
-        public short OutOfRangeThresholdInDBm { get => _outOfRangeThresholdInDBm; set => _outOfRangeThresholdInDBm = value; }
+        public short OutOfRangeThresholdInDBm 
+        { 
+            get => _outOfRangeThresholdInDBm;
+            set
+            { 
+                if ( value > 20 || value < -127)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                _outOfRangeThresholdInDBm = value;
+            }
+        }
 
         /// <summary>
         /// The minimum received signal strength indicator (RSSI) value in dBm on which RSSI
         /// events will be propagated or considered in range if the previous events were
         /// considered out of range. Value between +20 and -127. Default vale is -127.
         /// </summary>
-        public short InRangeThresholdInDBm { get => _inRangeThresholdInDBm; set => _inRangeThresholdInDBm = value; }
+        public short InRangeThresholdInDBm 
+        { 
+            get => _inRangeThresholdInDBm;
+            set 
+            {
+                if (value > 20 || value < -127)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                _inRangeThresholdInDBm = value; 
+            } 
+        }
 
         /// <summary>
         /// Signal strength filter (RSSI).

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProvider.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Runtime.CompilerServices;
 using nanoFramework.Runtime.Native;
 using nanoFramework.Device.Bluetooth;
+using nanoFramework.Device.Bluetooth.Advertisement;
 
 namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
 {
@@ -23,14 +24,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         private GattLocalService _service;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private bool _isDiscoverable = true;
+        private BluetoothLEAdvertisementPublisher _publisher;
 
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private bool _isConnectable = true;
-
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private Buffer _serviceData;
-       
         internal GattServiceProvider(Guid serviceUuid)
         {
             // Add local service
@@ -51,7 +46,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// </summary>
         private void AddDeviceInformationService()
         {
-            // Add and initialised Device Information defaults
+            // Add and initialized Device Information defaults
             GattServiceProvider ServiceProvider = new GattServiceProvider(GattServiceUuids.DeviceInformation);
             GattLocalService dinfService = ServiceProvider.Service;
 
@@ -98,20 +93,110 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
                 BluetoothLEServer.Instance.Start();
             }
 
-            // Save parameters
-            _isConnectable = parameters.IsConnectable;
-            _isDiscoverable = parameters.IsDiscoverable;
-            _serviceData = parameters.ServiceData;
-
             // Make sure pairing attributes set
             BluetoothLEServer.Instance.Pairing.SetPairAttributes();
 
-            // Start advertising.
-            // Native code will use the data provided by this GattServiceProvider instance to
-            // initialise the BLE advert, service and characteristic definitions.
-            if (NativeStartAdvertising(BluetoothLEServer._services))
+            // Save IsConnectable & IsDiscoverable options in Advertisement
+            parameters.Advertisement.IsConnectable = parameters.IsConnectable;
+            parameters.Advertisement.IsDiscovable = parameters.IsDiscoverable;
+
+            // Initialize Service configuration data in native code.
+            if ( NativeInitializeServiceConfig(BluetoothLEServer._services))
             {
-                _status = GattServiceProviderAdvertisementStatus.Started;
+                // Add default data sections for Service Provider to Advertisement if
+                // not custom.
+                if (!parameters.CustomAdvertisement)
+                {
+                    BluetoothLEAdvertisementDataSectionType suType;
+                    DataWriter suDataWriter = new();
+
+                    // Add Service UUID
+                    switch (Utilities.TypeOfUuid(_service.Uuid))
+                    {
+                        case Utilities.UuidType.Uuid16:
+                            suType = BluetoothLEAdvertisementDataSectionType.CompleteList16uuid;
+                            suDataWriter.WriteUInt16(Utilities.ConvertUuidToShortId(_service.Uuid));
+                            break;
+
+                        case Utilities.UuidType.Uuid32:
+                            suType = BluetoothLEAdvertisementDataSectionType.CompleteList32uuid;
+                            suDataWriter.WriteUInt32(Utilities.ConvertUuidToIntId(_service.Uuid));
+                            break;
+
+                        case Utilities.UuidType.Uuid128:
+                        default:
+                            suType = BluetoothLEAdvertisementDataSectionType.CompleteList128uuid;
+                            suDataWriter.WriteUuid(_service.Uuid);
+                            break;
+                    }
+
+                    // Add Service UUID with correct type for UUID size.
+                    parameters.Advertisement.AddOrUpdateDataSection(
+                        suType,
+                        suDataWriter.DetachBuffer());
+
+                    // Add Service Data including Service UUID if required.
+                    if (parameters.ServiceData != null)
+                    {
+                        BluetoothLEAdvertisementDataSectionType sdType;
+                        DataWriter sdDataWriter = new();
+
+                        switch (Utilities.TypeOfUuid(_service.Uuid))
+                        {
+                            case Utilities.UuidType.Uuid16:
+                                sdType = BluetoothLEAdvertisementDataSectionType.ServiceData16bitUuid;
+                                sdDataWriter.WriteUInt16(Utilities.ConvertUuidToShortId(_service.Uuid));
+                                break;
+
+                            case Utilities.UuidType.Uuid32:
+                                sdType = BluetoothLEAdvertisementDataSectionType.ServiceData32bitUuid;
+                                sdDataWriter.WriteUInt32(Utilities.ConvertUuidToIntId(_service.Uuid));
+                                break;
+
+                            case Utilities.UuidType.Uuid128:
+                            default:
+                                sdType = BluetoothLEAdvertisementDataSectionType.ServiceData128bitUuid;
+                                sdDataWriter.WriteUuid(_service.Uuid);
+                                break;
+                        }
+                        // Write service data after UUID
+                        sdDataWriter.WriteBytes(parameters.ServiceData.Data);
+
+                        // Add Service Data with correct type for UUID size.
+                        parameters.Advertisement.AddOrUpdateDataSection(
+                            sdType,
+                            sdDataWriter.DetachBuffer());
+                    }
+                }
+
+                _publisher = new BluetoothLEAdvertisementPublisher(parameters.Advertisement);
+                _publisher.StatusChanged += Publisher_StatusChanged;
+
+                // Start advertising.
+                _publisher.Start();
+            }
+        }
+
+        private void Publisher_StatusChanged(object sender, BluetoothLEAdvertisementPublisherStatusChangedEventArgs args)
+        {
+            switch(args.Status)
+            {
+                case BluetoothLEAdvertisementPublisherStatus.Started:
+                    _status = _publisher.DataNotFitInAdvertisement?
+                        GattServiceProviderAdvertisementStatus.StartedWithoutAllAdvertisementData:
+                        GattServiceProviderAdvertisementStatus.Started;
+                    break;
+
+                case BluetoothLEAdvertisementPublisherStatus.Stopped:
+                    _status = GattServiceProviderAdvertisementStatus.Stopped;
+
+                    NativeDisposeServiceConfig();
+                    BluetoothNanoDevice.RunMode = BluetoothNanoDevice.Mode.NotRunning;
+                    break;
+
+                case BluetoothLEAdvertisementPublisherStatus.Aborted:
+                    _status = GattServiceProviderAdvertisementStatus.Aborted;
+                    break;
             }
         }
 
@@ -120,12 +205,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// </summary>
         public void StopAdvertising()
         {
-            // Stop advertising and dispose of native data.
-            NativeStopAdvertising();
-
-            _status = GattServiceProviderAdvertisementStatus.Stopped;
-
-            BluetoothNanoDevice.RunMode = BluetoothNanoDevice.Mode.NotRunning;
+            // Stop advertising and dispose of native data when stopped event received.
+            _publisher.Stop();
         }
 
         /// <summary>
@@ -171,10 +252,10 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         #region external calls to native implementations
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern bool NativeStartAdvertising(ArrayList services);
+        private extern bool NativeInitializeServiceConfig(ArrayList services);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern void NativeStopAdvertising();
+        private extern void NativeDisposeServiceConfig();
 
         #endregion
     }

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProviderAdvertisingParameters.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattServiceProviderAdvertisingParameters.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using nanoFramework.Device.Bluetooth.Advertisement;
 using System;
 
 namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
@@ -21,17 +22,45 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private Buffer _serviceData;
 
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private BluetoothLEAdvertisement _advertisement;
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private bool _customAdvertisement;
+
+
         /// <summary>
         ///  Creates a new GattServiceProviderAdvertisingParameters object.
         /// </summary>
         public GattServiceProviderAdvertisingParameters()
         {
+            _advertisement = new();
+            
+            // Not a Custom advertisement, so set Flags & Local Name 
+            CustomAdvertisement = false; 
+            
+            _isDiscoverable = true;
         }
 
         /// <summary>
         /// Gets or sets a boolean indicating that the GATT service is discoverable.
         /// </summary>
-        public bool IsDiscoverable { get => _isDiscoverable; set => _isDiscoverable = value; }
+        public bool IsDiscoverable
+        {
+            get => _isDiscoverable;
+            set
+            {
+                _isDiscoverable = value;
+                if (_isDiscoverable)
+                {
+                    _advertisement.Flags |= BluetoothLEAdvertisementFlags.GeneralDiscoverableMode;
+                }
+                else
+                {
+                    _advertisement.Flags &= ~BluetoothLEAdvertisementFlags.GeneralDiscoverableMode;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets a boolean that indicates if the GATT service is connect-able.
@@ -45,5 +74,39 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// also be included in the same section in the advertisement.
         /// </summary>
         public Buffer ServiceData { get => _serviceData; set => _serviceData = value; }
+
+        /// <summary>
+        /// Gets the underlying BluetoothLEAdvertisement object for the GattServiceProviderAdvertisingParameters to enable extra 
+        /// advertisement parameters to be set.
+        /// </summary>
+        public BluetoothLEAdvertisement Advertisement { get => _advertisement; }
+
+        /// <summary>
+        /// If set the Advertisement will not be filled in with the default data sections only data sections from
+        /// the Advertisement property will be used. Default is false.
+        /// </summary>
+        public bool CustomAdvertisement 
+        { 
+            get => _customAdvertisement; 
+            set
+            {
+                _customAdvertisement = value;
+                if (_customAdvertisement)
+                {
+                    // Remove default data sections
+                    Advertisement.RemoveSectionsOfType(BluetoothLEAdvertisementDataSectionType.Flags);
+                    Advertisement.RemoveSectionsOfType(BluetoothLEAdvertisementDataSectionType.CompleteLocalName);
+                }
+                else
+                {
+                    // Add default data sections
+                    Advertisement.Flags = BluetoothLEAdvertisementFlags.ClassicNotSupported |
+                                           BluetoothLEAdvertisementFlags.GeneralDiscoverableMode;
+
+                    // Set default device name
+                    Advertisement.LocalName = BluetoothLEServer.Instance.DeviceName;
+                }
+            }
+        }
     }
 }

--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattSession.cs
@@ -14,7 +14,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
     public class GattSession
     {
         private readonly BluetoothDeviceId _deviceId;
-        private ushort _maxPduSize;
+        private ushort _maxMtuSize;
 
         /// <summary>
         /// Delegate for SessionStatusChanged events.
@@ -64,8 +64,8 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
                     break;
 
                 case BluetoothEventType.ClientSessionChanged:
-                    // Update maxpdu size in GattSession
-                    _maxPduSize = btEvent.data;
+                    // Update max MTU size in GattSession
+                    _maxMtuSize = btEvent.data;
                     MaxPduSizeChanged?.Invoke(this, EventArgs.Empty);
                     break;
             }
@@ -77,10 +77,9 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         public BluetoothDeviceId DeviceId { get => _deviceId; }
 
         /// <summary>
-        /// Gets the maximum protocol data unit (PDU) size. 
-        /// This metric is also known as the maximum transmission unit (MTU) size.
+        /// Gets the maximum transmission unit (MTU) size. 
         /// </summary>
-        public ushort MaxPduSize { get => _maxPduSize; }
+        public ushort MaxMtuSize { get => _maxMtuSize; }
 
     }
 }

--- a/nanoFramework.Device.Bluetooth/IO/DataReader.cs
+++ b/nanoFramework.Device.Bluetooth/IO/DataReader.cs
@@ -138,6 +138,50 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
+        /// Reads a UUID value from the input buffer.
+        /// </summary>
+        /// <returns>The UUID value.</returns>
+        public Guid ReadUuid()
+        {
+            byte[] srcArray = new byte[16];
+            byte[] tarArray = new byte[16];
+
+            // read position update and check are performed on the call
+            ReadBytes(srcArray);
+
+            // Fix order
+            int ti = 0;
+            foreach (int index in new int[] { 12, 13, 14, 15, 10, 11, 8, 9, 7, 6, 5, 4, 3, 2, 1, 0 })
+            {
+                tarArray[ti++] = srcArray[index];
+            }
+
+            return new Guid(tarArray);
+        }
+
+        /// <summary>
+        /// Reads a UUID value from the input buffer which has been written with WriteUuid2
+        /// </summary>
+        /// <returns>The GUID/UUID value.</returns>
+        public Guid ReadUuid2()
+        {
+            byte[] srcArray = new byte[16];
+            byte[] tarArray = new byte[16];
+
+            // read position update and check are performed on the call
+            ReadBytes(srcArray);
+
+            // Fix order
+            int ti = 0;
+            foreach (int index in new int[] { 3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15 })
+            {
+                tarArray[ti++] = srcArray[index];
+            }
+
+            return new Guid(tarArray);
+        }
+
+        /// <summary>
         /// Reads a 16-bit integer value from the input buffer.
         /// </summary>
         /// <returns>The value.</returns>

--- a/nanoFramework.Device.Bluetooth/IO/DataWriter.cs
+++ b/nanoFramework.Device.Bluetooth/IO/DataWriter.cs
@@ -115,6 +115,40 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
+        /// Writes a UUID value to the output stream using order expected for service UUIDs.
+        /// The order of bytes is reverse of bytes when displayed.
+        /// </summary>
+        /// <param name="value">The UUID value to write.</param>
+        public void WriteUuid(Guid value)
+        {
+            InternalWriteGuid(value, new int[] { 15, 14, 13, 12, 11, 10, 9, 8, 6, 7, 4, 5, 0, 1, 2, 3 });
+        }
+
+        /// <summary>
+        /// Write a UUID value to the output stream using order expected by Beacon advertisements.
+        /// The order of bytes is same as when displayed.
+        /// </summary>
+        /// <param name="value"></param>
+        public void WriteUuid2(Guid value)
+        {
+            InternalWriteGuid(value, new int[] { 3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15 });
+        }
+
+        private void InternalWriteGuid(Guid value, int[] order)
+        {
+            byte[] srcUuid = value.ToByteArray();
+            byte[] tarUuid = value.ToByteArray();
+
+            // Fix order
+            int ti = 0;
+            foreach (int index in order)
+            {
+                tarUuid[ti++] = srcUuid[index];
+            }
+            WriteBytes(tarUuid);
+        }
+
+        /// <summary>
         /// Writes a 16-bit integer value to the output stream.
         /// </summary>
         /// <param name="value">The value to write.</param>

--- a/nanoFramework.Device.Bluetooth/Utilities.cs
+++ b/nanoFramework.Device.Bluetooth/Utilities.cs
@@ -2,6 +2,7 @@
 // Copyright (c) .NET Foundation and Contributors
 // See LICENSE file in the project root for full license information.
 //
+using nanoFramework.Device.Bluetooth.Advertisement;
 using System;
 
 namespace nanoFramework.Device.Bluetooth
@@ -11,6 +12,29 @@ namespace nanoFramework.Device.Bluetooth
     /// </summary>
     public static class Utilities
     {
+        // UUID is the name used by Bluetooth SIG for a Guid
+        // This value is the base UUID for all standard Bluetooth SIG UUIDs.
+        private static byte[] baseUuid = new Guid("00000000-0000-1000-8000-00805f9b34fb").ToByteArray();
+
+        /// <summary>
+        /// Type of UUID.
+        /// </summary>
+        public enum UuidType 
+        { 
+            /// <summary>
+            /// 16 bit UUID.
+            /// </summary>
+            Uuid16, 
+            /// <summary>
+            /// 32 bit UUID.
+            /// </summary>
+            Uuid32, 
+            /// <summary>
+            /// 128 bit UUID
+            /// </summary>
+            Uuid128 
+        };
+
         /// <summary>
         /// This enum assists in finding a string representation of a BT SIG assigned value for Descriptor UUIDs
         /// Reference: https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorsHomePage.aspx
@@ -98,7 +122,7 @@ namespace nanoFramework.Device.Bluetooth
         ///  that devices expose to the standard list.
         /// </summary>
         /// <param name="uuid">UUID to convert to 16 bit short code Uuid</param>
-        /// <returns></returns>
+        /// <returns>16bit UUID as ushort value.</returns>
         public static ushort ConvertUuidToShortId(Guid uuid)
         {
             // Get the short Uuid
@@ -108,24 +132,85 @@ namespace nanoFramework.Device.Bluetooth
         }
 
         /// <summary>
+        ///  Converts from standard 128bit UUID to the assigned 32bit UUID. 
+        /// </summary>
+        /// <param name="uuid">UUID to convert to 32 bit short code Uuid.</param>
+        /// <returns>32bit UUID as uint value.</returns>
+        public static UInt32 ConvertUuidToIntId(Guid uuid)
+        {
+            byte[] bytes = uuid.ToByteArray();
+            return (UInt32)((bytes[2] << 24) + (bytes[3] << 16) + (bytes[0] << 8) + bytes[1]);
+        }
+
+        /// <summary>
         /// Create a Uuid/Guid from a short Bluetooth SIG short UUID
         /// </summary>
         /// <param name="uuid16">Bluetooth Short code UUID</param>
         /// <returns>A Guid using Bluetooth SIG UUID</returns>
         public static Guid CreateUuidFromShortCode(ushort uuid16)
         {
-            // UUID is the name used by Bluetooth SIG for a Guid
-            // This is the base UUID for all standard Bluetooth SIG UUIDs 
-            const string baseUuid = "00000000-0000-1000-8000-00805f9b34fb";
-
-            Guid temp = new Guid(baseUuid);
-
-            byte[] bytes = temp.ToByteArray();
+            byte[] bytes = new byte[16];
+            baseUuid.CopyTo(bytes, 0);
 
             bytes[0] = (byte)(0x00ff & uuid16);
             bytes[1] = (byte)(uuid16 >> 8);
 
             return new Guid(bytes);
+        }
+
+        /// <summary>
+        /// Is the GUID a Bluetooth SIG UUID, 16bit or 32bit.
+        /// </summary>
+        /// <param name="uuid">Guid with UUID value.</param>
+        /// <returns>True if Bluetooth SIG UUID.</returns>
+        public static bool IsBluetoothSigUUID(Guid uuid)
+        {
+            byte[] bytes = uuid.ToByteArray();
+            for(int index=0; index<baseUuid.Length; index++)
+            {
+                if (baseUuid[index] != bytes[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Is passed Bluetooth SIG UUID a 16bit UUID format. 
+        /// </summary>
+        /// <param name="uuid">Guid with UUID Sig value.</param>
+        /// <returns>True if Sig UUID is 16bit UUID</returns>
+        public static bool IsBluetoothSigUUID16(Guid uuid) 
+        {
+            byte[] bytes = uuid.ToByteArray();
+            return (bytes[2] == 0) && (bytes[3] == 0);    
+        }
+
+        /// <summary>
+        /// Return the type of passed UUID.
+        /// </summary>
+        /// <param name="uuid">UUID to test.</param>
+        /// <returns>UUID type.</returns>
+        public static UuidType TypeOfUuid(Guid uuid)
+        {
+            if (Utilities.IsBluetoothSigUUID(uuid))
+            {
+                // 16 bit or 32 bit Bluetooth SIG UUID
+                if (Utilities.IsBluetoothSigUUID16(uuid))
+                {
+                    // 16bit UUID
+                    return UuidType.Uuid16;
+                }
+                else
+                {
+                    // 32bit UUID
+                    return UuidType.Uuid32;
+                }
+            }
+
+            return UuidType.Uuid128;
         }
     }
 }

--- a/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
+++ b/nanoFramework.Device.Bluetooth/nanoFramework.Device.Bluetooth.nfproj
@@ -38,6 +38,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="Advertisement\BluetoothLEAdvertisementBytePattern.cs" />
+    <Compile Include="Advertisement\BluetoothLEAdvertisementPublisher.cs" />
+    <Compile Include="Advertisement\BluetoothLEAdvertisementPublisherStatus.cs" />
+    <Compile Include="Advertisement\BluetoothLEAdvertisementPublisherStatusChangedEventArgs.cs" />
+    <Compile Include="Advertisement\BluetoothLEAdvertisementDataSectionType.cs" />
     <Compile Include="BluetoothAddress.cs" />
     <Compile Include="BluetoothAddressType.cs" />
     <Compile Include="BluetoothConnectionStatus.cs" />


### PR DESCRIPTION
## Description

- Adds BluetoothLEAdvertisementPublisher class and associated classes and events to allow advertisements to be created without service definitions fir use in beacons.
- Update BluetoothLEAdvertisement for creating advertisements.
- Adds BluetoothLEAdvertisementFilter for filtering advertisements by content with associated classes.
- Update BluetoothSignalStrengthFilter to check property values ranges.
- Update GattServiceProvider to use BluetoothLEAdvertisementPublisher for advertisements.
- Update GattServiceProviderAdvertisingParameters to allow for a customAdvertisements for use with GattServiceProvider. 
- Update GattServiceProviderAdvertisingParameters to use BluetoothLEAdvertisement and expose as property to allow other advertisement data sections to be added, like "ManufacturerData"
- Fix various typos in comments
- Update Readme with new features and changes.

## Motivation and Context

- Fixes nanoFramework/Home#1236

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
