### PR TITLE
Enable Notify or Indication ability to change default GattWriteOption

### DIFF
--- a/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristic.cs
+++ b/nanoFramework.Device.Bluetooth/GenericAttributeProfile/GattCharacteristic.cs
@@ -157,7 +157,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
         /// <returns>
         /// Returns an asynchronous operation that completes with a GattWriteResult object.
         /// </returns>
-        public GattWriteResult WriteClientCharacteristicConfigurationDescriptorWithResult(GattClientCharacteristicConfigurationDescriptorValue clientCharacteristicConfigurationDescriptorValue)
+        public GattWriteResult WriteClientCharacteristicConfigurationDescriptorWithResult(GattClientCharacteristicConfigurationDescriptorValue clientCharacteristicConfigurationDescriptorValue, GattWriteOption gattWriteOption = GattWriteOption.WriteWithoutResponse)
         {
             GattCommunicationStatus status = GattCommunicationStatus.AccessDenied;
             byte protocolError = 0;
@@ -181,7 +181,7 @@ namespace nanoFramework.Device.Bluetooth.GenericAttributeProfile
                     GattWriteResult wr = _service.Device.WriteAttributeValueWithResult(
                         _cccdDescriptorHandle,
                         dw.DetachBuffer(),
-                        GattWriteOption.WriteWithoutResponse);
+                        gattWriteOption);
 
                     if (wr.Status == 0)
                     {


### PR DESCRIPTION

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Currently the default for the `WriteClientCharacteristicConfigurationDescriptorWithResult` has a default GattWriteOption as `GattWriteOption.WriteWithoutResponse`, which work for most case.  In some bluetooth implemenation `GattWriteOption.WriteResponse` is needed otherwise the notify/indicate event will never fire.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with ESP32 and ESP32 S3  bluetooth.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
